### PR TITLE
Color Fixes

### DIFF
--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -13,7 +13,7 @@ $grey-light: #BBBBBB;
 $grey-lighter: #CCCCCC;
 $grey-lightest: #EEEEEE;
 
-// Primary Palette
+// Primary Palette (dark blue)
 $primary: #023658;
 $primary-dark: #02304F;
 $primary-darker: #012842;
@@ -22,8 +22,8 @@ $primary-light: #1c4a69;
 $primary-lighter: #416882;
 $primary-lightest: #819bac;
 
-// Secondary Palette
-$secondary: #ff6600;
+// Secondary Palette (turquoise)
+$secondary: #379f86;
 $secondary-dark: #e55c00;
 $secondary-darker: #bf4c00;
 $secondary-darkest: #7f3300;
@@ -32,9 +32,9 @@ $secondary-lighter: #ff8c40;
 $secondary-lightest: #ffb380;
 
 // Primary Accent
-$accent-primary: #127AB3;
-$accent-primary-light: #89BDD9;
-$accent-primary-dark: #093D59;
+$accent-primary: #09a0db;
+$accent-primary-light: #39b3e1;
+$accent-primary-dark: #0f6e9e;
 
 // Success Accent
 $accent-success: #6EA23D;
@@ -55,7 +55,7 @@ $accent-danger-dark: #7F1E18;
 $accent-active: #179FCA;
 
 // Backgrounds
-$base-background-color: $grey-lightest;
+$base-background-color: #f5f6f7;
 $panel-primary: $white;
 $panel-secondary: #F9F9F9;
 


### PR DESCRIPTION
This is not a PR I enjoy - We need a longer-term fix for this, after discussing solutions with Rob. The style guide, in its current incarnation, is not always web- or SASS-friendly. A rundown of the big'uns:
* There are a few too many color palette options
* It's unclear what's primary, secondary, tertiary, and primary/secondary accent. The primary vs secondary colors seem out of order
* There are colors referenced in portions of the guide that are not defined in the palettes
* It's unclear what the accents to the right of the primary palettes are for or where they're used

This PR invalidates some good variable naming in `employer` that must be restored: for example, instead of `.text--accent` using the aptly-named `$accent-primary` color variable, it uses `$secondary`. This is a stopgap until we can come up with a more logical palette naming scheme, and a slightly pared down palette.