### PR TITLE
Change button border radii to 3px and add variable for 3px radii

### DIFF
--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -20,8 +20,9 @@ $header-line-height: 1.25;
 
 // Other Sizes
 $base-border-radius: 5px;
-$button-border-radius: $base-border-radius;
-$panel-border-radius: 3px;
+$minor-border-radius: 3px;
+$button-border-radius: $minor-border-radius;
+$panel-border-radius: $minor-border-radius;
 $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
 $base-spacing: $base-line-height * 1em;


### PR DESCRIPTION
May need better naming convention and more clean up. For example, do we still need a `$base-border-radius: 5px`? Should `$radio-border-radius` equal 50 and not a calculation?

Adding to list of things to consider and refactor