### PR TITLE
EM-384: Create Link Extend and Update Link Styles

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -11,6 +11,7 @@
 @import "directives/flashes";
 @import "directives/gradients";
 @import "directives/groups";
+@import "directives/link";
 @import "directives/panels";
 @import "directives/visibility";
 

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -39,18 +39,7 @@ p {
 }
 
 a {
-  @include transition(color 0.1s linear);
-  color: $base-link-color;
-  text-decoration: none;
-
-  &:hover {
-    color: $hover-link-color;
-  }
-
-  &:active, &:focus {
-    color: $hover-link-color;
-    outline: none;
-  }
+  @extend %link;
 }
 
 hr {

--- a/sass/directives/_link.scss
+++ b/sass/directives/_link.scss
@@ -1,0 +1,19 @@
+%link {
+  @include transition(color 0.1s linear);
+  color: $base-link-color;
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+  }
+
+  &:visited {
+    color: $visited-link-color;
+  }
+
+  &:active, &:focus {
+    outline: none;
+  }
+}

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -22,6 +22,7 @@ $emerald: #009B74;
 $red: #DD4D39;
 $orange: #E78523;
 $teal: #63C0B9;
+$purple: #662d91;
 
 $azure-two: #1280A1;
 $azure-blue: #287AB9;
@@ -60,6 +61,7 @@ $base-accent-color: $emerald;
 // Links
 $base-link-color: $sky-blue;
 $hover-link-color: $sky-blue-light;
+$visited-link-color: $purple;
 
 // Backgrounds
 $base-background-color: $grey-lightest;
@@ -167,3 +169,8 @@ $base-border-secondary: 1px solid $base-border-secondary-color;
 $form-border-color: $base-border-primary-color;
 $form-border-color-hover: darken($base-border-primary-color, 10);
 $form-border-color-focus: $alert-primary;
+
+// TODO Adding links here for EM-384. Can remove and use typography.scss with EM-386
+a {
+  @extend %link;
+}


### PR DESCRIPTION
- Add a new directive for link styles
- Apply directive in both typography and colors
  - Typography stylesheet isn't used on this branch. It will be implemented with EM-383
  - So wanted to update typography for when the link styles are merged into the in-progress typography branch, but also added the new links to colors so they could be used for now. They will be removed