### PR TITLE
EM-383: Style Guide Updates: Typography

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -25,10 +25,13 @@
   // Typography and Elements
   @include font-feature-settings("kern", "liga", "frac", "pnum");
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   background-color: $base-background-color;
   color: $body-text-color;
-  // font-size: $base-font-size;
-  // line-height: $base-line-height;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  line-height: $base-line-height;
+  font-weight: 400;
 
 
   // @import "forms";

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -15,6 +15,9 @@
 @import "directives/panels";
 @import "directives/visibility";
 
+@import "typography";
+@import "buttons";
+
 .employer-scope {
   // Reset
   // @import 'reset';
@@ -27,8 +30,7 @@
   // font-size: $base-font-size;
   // line-height: $base-line-height;
 
-  @import "typography";
+
   // @import "forms";
   // @import "lists";
-  @import "buttons";
 }

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -28,7 +28,7 @@
   // font-size: $base-font-size;
   // line-height: $base-line-height;
 
-  // @import "typography";
+  @import "typography";
   // @import "forms";
   // @import "lists";
   @import "buttons";

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -24,7 +24,6 @@
   -webkit-font-smoothing: antialiased;
   background-color: $base-background-color;
   color: $body-text-color;
-  // font-family: $base-font-family;
   // font-size: $base-font-size;
   // line-height: $base-line-height;
 

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -31,7 +31,7 @@
   font-family: $base-font-family;
   font-size: $base-font-size;
   line-height: $base-line-height;
-  font-weight: 400;
+  font-weight: $font-weight-normal;
 
 
   // @import "forms";

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,4 +1,5 @@
 // Variables
+@import "variables/breakpoints.scss";
 @import "variables/colors";
 @import "variables/sizing";
 

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -6,6 +6,7 @@ select {
 
 label {
   margin-bottom: $base-spacing / 4;
+  font-weight: $font-weight-bold;
 
   &.required:after {
     // TODO: Make this an icon on an input field, instead

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -1,3 +1,12 @@
+@import url(https://fonts.googleapis.com/css?family=Lato:300,400,700);
+
+// Typography
+$lato: Lato, 'Lato', Helvetica, Arial, sans-serif;
+
+$base-font-family: $lato;
+$header-font-family: $lato;
+$form-font-family: $base-font-family;
+
 h1,
 h2,
 h3,

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -16,6 +16,7 @@ h6 {
   color: $header-text-color;
   font-family: $header-font-family;
   line-height: $header-line-height;
+  font-weight: 700;
   margin: 0;
 }
 

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -11,20 +11,21 @@ $font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 
+$base-bottom-margin: $base-spacing / 2;
+
 h1,
 h2,
 h3,
 h4,
 h5,
-h6,
-.text--headline,
-.text--headline a {
+h6 {
   font-family: $header-font-family;
   line-height: $header-line-height;
   font-weight: $font-weight-bold;
   color: $header-text-color;
   text-decoration: none;
   margin: 0;
+  margin-bottom: $base-bottom-margin;
 }
 
 h1,
@@ -59,7 +60,7 @@ h6,
 
 p {
   font-size: $base-font-size;
-  margin-bottom: ($base-spacing / 2);
+  margin-bottom: $base-bottom-margin;
   line-height: $base-line-height;
 
   &:last-child {

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -7,47 +7,64 @@ $base-font-family: $lato;
 $header-font-family: $lato;
 $form-font-family: $base-font-family;
 
+$font-weight-light: 300;
+$font-weight-normal: 400;
+$font-weight-bold: 700;
+
 h1,
 h2,
 h3,
 h4,
 h5,
-h6 {
-  color: $header-text-color;
+h6,
+.text--headline,
+.text--headline a {
   font-family: $header-font-family;
   line-height: $header-line-height;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
+  color: $header-text-color;
+  text-decoration: none;
   margin: 0;
 }
 
-h1 {
+h1,
+.text--headline-1 {
   font-size: $h1-font-size;
 }
 
-h2 {
+h2,
+.text--headline-2 {
   font-size: $h2-font-size;
 }
 
-h3 {
+h3,
+.text--headline-3 {
   font-size: $h3-font-size;
 }
 
-h4 {
+h4,
+.text--headline-4 {
   font-size: $h4-font-size;
 }
 
-h5 {
+h5,
+.text--headline-5 {
   font-size: $h5-font-size;
 }
 
-h6 {
+h6,
+.text--headline-6 {
   font-size: $h6-font-size;
 }
 
 p {
   font-size: $base-font-size;
-  margin: 0 0 ($base-spacing / 2);
+  margin-bottom: ($base-spacing / 2);
   line-height: $base-line-height;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 a {
@@ -62,10 +79,8 @@ hr {
   margin: $base-spacing 0;
 }
 
-img,
-picture {
-  margin: 0;
-  max-width: 100%;
+ul.list--body {
+  margin-left: 20px;
 }
 
 blockquote {
@@ -82,4 +97,17 @@ cite {
   &:before {
     content: "\2014 \00A0";
   }
+}
+
+// UX Style guide does not specify these styles, but this class is also not currently in use. Consult with UX if using.
+.text--caption {
+  font-weight: $font-weight-normal;
+  font-size: $caption-font-size;
+  line-height: $base-line-height;
+}
+
+.text--details {
+  font-weight: $font-weight-normal;
+  font-size: $base-font-size;
+  line-height: $base-line-height;
 }

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -45,7 +45,9 @@ h6 {
 }
 
 p {
+  font-size: $base-font-size;
   margin: 0 0 ($base-spacing / 2);
+  line-height: $base-line-height;
 }
 
 a {

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -11,6 +11,14 @@ $font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 
+.light {
+  font-weight: $font-weight-light;
+}
+
+.heavy {
+  font-weight: $font-weight-bold;
+}
+
 $base-bottom-margin: $base-spacing / 2;
 
 h1,

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -3,24 +3,17 @@
 // Typography
 $lato: Lato, 'Lato', Helvetica, Arial, sans-serif;
 
+// Typefaces
 $base-font-family: $lato;
 $header-font-family: $lato;
 $form-font-family: $base-font-family;
 
+// Font Weights
 $font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 
-.light {
-  font-weight: $font-weight-light;
-}
-
-.heavy {
-  font-weight: $font-weight-bold;
-}
-
-$base-bottom-margin: $base-spacing / 2;
-
+// Headers
 h1,
 h2,
 h3,
@@ -119,4 +112,12 @@ cite {
   font-weight: $font-weight-normal;
   font-size: $base-font-size;
   line-height: $base-line-height;
+}
+
+.light {
+  font-weight: $font-weight-light;
+}
+
+.heavy {
+  font-weight: $font-weight-bold;
 }

--- a/sass/variables/_breakpoints.scss
+++ b/sass/variables/_breakpoints.scss
@@ -1,0 +1,11 @@
+// Mobile breakpoints
+// Breakpoints used by Zurb Foundation
+// Zurb has breakpoints for XL and XXL, not used here.
+$small-screen-max: 40em; // (640px)
+$medium-screen-min: 40em;
+$medium-screen-max: 64em; // (1024px)
+$large-screen-min: 64em;
+
+// Nav breakpoints
+$midrange-nav-max: 71.875em; // (1150px) Point at which full nav no longer fits in one line
+$mobile-nav-max: 60.75em; // (972px) Point at which full nav + collapsed right-side nav no longer fit in one line

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -166,8 +166,3 @@ $base-border: 1px solid $base-border-primary-color;
 $form-border-color: $base-border-primary-color;
 $form-border-color-hover: darken($base-border-primary-color, 10);
 $form-border-color-focus: $alert-primary;
-
-// TODO Adding links here for EM-384. Can remove and use typography.scss with EM-386
-a {
-  @extend %link;
-}

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -27,7 +27,6 @@ $form-border-radius: $base-border-radius;
 $form-box-shadow: inset 0 1px 3px rgba($black, 0.06);
 $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color-focus, 5), 0.7);
 $form-font-size: $base-font-size;
-$form-font-family: $base-font-family;
 
 // Input Sizes
 $base-input-font-size: $form-font-size;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,12 +1,21 @@
 // Font Sizes
 $base-font-size: 1em;
+
 $top-bar--nav-font: 13px;
+
+// TODO used in footer copyright and on email form error messages. No guidance in UX style guide. Undecided on whether we need variables
+$text-smaller: 80%;
+$text-larger: 120%;
+
 $h1-font-size: $base-font-size * 2;
 $h2-font-size: $base-font-size * 1.5;
 $h3-font-size: $base-font-size * 1.17;
 $h4-font-size: $base-font-size;
 $h5-font-size: $base-font-size * 0.83;
 $h6-font-size: $base-font-size * 0.67;
+
+$subhead-font-size: $base-font-size * 1.5;
+$caption-font-size: $base-font-size * 0.83;
 
 // Line height
 $base-line-height: 1.5;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -31,6 +31,10 @@ $base-spacing: $base-line-height * 1em;
 $base-z-index: 0;
 $base-bottom-margin: $base-spacing / 2;
 
+// UI components
+$direction-arrow-size: 2em;
+$close-x-size: 18px;
+
 // Forms
 $form-border-radius: $base-border-radius;
 $form-box-shadow: inset 0 1px 3px rgba($black, 0.06);

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -29,6 +29,7 @@ $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
 $base-spacing: $base-line-height * 1em;
 $base-z-index: 0;
+$base-bottom-margin: $base-spacing / 2;
 
 // Forms
 $form-border-radius: $base-border-radius;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,7 +1,6 @@
 // Font Sizes
 $base-font-size: 1em;
-
-$top-bar--nav-font: 13px;
+$small-font-size: 13px;
 
 // TODO used in footer copyright and on email form error messages. No guidance in UX style guide. Undecided on whether we need variables
 $text-smaller: 80%;
@@ -15,7 +14,7 @@ $h5-font-size: $base-font-size * 0.83;
 $h6-font-size: $base-font-size * 0.67;
 
 $subhead-font-size: $base-font-size * 1.5;
-$caption-font-size: $base-font-size * 0.83;
+$caption-font-size: $small-font-size;
 
 // Line height
 $base-line-height: 1.5;
@@ -84,6 +83,7 @@ $top-bar--height: 60px;
 $top-bar--height--mobile: 42px;
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 32px;
+$top-bar-font-size: $small-font-size;
 
 // Form Elements
 $base-radio-box-shadow: 0 0 0 1px $grey inset, 0 0 0 9px $white inset, 0 0 0 10px $grey inset;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,10 +1,3 @@
-// Typography
-$lato: Lato, 'Lato', Helvetica, Arial, sans-serif;
-
-$base-font-family: $lato;
-$header-font-family: $lato;
-$form-font-family: $base-font-family;
-
 // Font Sizes
 $base-font-size: 1em;
 $top-bar--nav-font: 13px;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,12 +1,12 @@
 // Font Sizes
 $base-font-size: 1em;
 $top-bar--nav-font: 13px;
-$h1-font-size: $base-font-size * 3;
-$h2-font-size: $base-font-size * 2.25;
-$h3-font-size: $base-font-size * 1.875;
-$h4-font-size: $base-font-size * 1.5;
-$h5-font-size: $base-font-size * 1.125;
-$h6-font-size: $base-font-size;
+$h1-font-size: $base-font-size * 2;
+$h2-font-size: $base-font-size * 1.5;
+$h3-font-size: $base-font-size * 1.17;
+$h4-font-size: $base-font-size;
+$h5-font-size: $base-font-size * 0.83;
+$h6-font-size: $base-font-size * 0.67;
 
 // Line height
 $base-line-height: 1.5;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -29,7 +29,10 @@ $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
 $base-spacing: $base-line-height * 1em;
 $base-z-index: 0;
+
+// Section Spacing
 $base-bottom-margin: $base-spacing / 2;
+$section--padding: 64px;
 
 // UI components
 $direction-arrow-size: 2em;


### PR DESCRIPTION
@toastercup @ElliottAYoung @kurtedelbrock 

- Implement the previously unused typography.scss
- Move typography and buttons out of employer-scope
- Update header styles per [style guide](https://app.frontify.com/d/6xYC97AVwz1E/style-guide#/basics/typography)
- Move type styles from [employer](https://github.com/cbdr/employer) to employer-style-base
- Add variables for font-weight, margin-bottom, small-font, UI elements
- Add heavy and light classes
- Move section padding variable to style-base
- Move employer breakpoints to style base