### PR TITLE
EM-322: Fix Image Size and Aspect-Ratio for Safari

### DIFF
--- a/sass/_content_grids.scss
+++ b/sass/_content_grids.scss
@@ -12,8 +12,8 @@
   margin: 2em; // not $base-spacing; forcing enough white space to keep max 4 items per row
 
   @media only screen and (max-width: $small-screen-max){
-    width: $image-grid-block * 0.625;
-    height: $image-grid-block * 0.625;
+    width: $image-grid-block / 2;
+    height: $image-grid-block / 2;
     margin: $base-spacing / 2;
   }
 }
@@ -28,4 +28,5 @@
   width: 100%;
   max-width: 100%;
   max-height: 100%;
+  object-fit: contain;
 }


### PR DESCRIPTION
- Add `object-fit` for Safari which distorts images that are more tall than wide
- Make images slightly smaller so they'll fit in two columns on mobile