### PR TITLE
EM-378: Form Styles and Email Subscription Card

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -18,6 +18,8 @@
 
 @import "typography";
 @import "buttons";
+
+@import "forms";
 @import "content_grids";
 
 .employer-scope {
@@ -35,7 +37,5 @@
   line-height: $base-line-height;
   font-weight: $font-weight-normal;
 
-
-  // @import "forms";
   // @import "lists";
 }

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -122,7 +122,7 @@ input {
   padding: $form-input-vertical-padding $form-input-horizontal-padding;
   border: $form-border;
   border-radius: $form-border-radius;
-  box-shadow: $base-box-shadow;
+  box-shadow: inset $base-box-shadow;
 
   @include placeholder {
     color: $form-placeholder-color;
@@ -146,8 +146,6 @@ input {
   }
 
   &__button.button {
-    box-shadow: $base-box-shadow;
-
     @media only screen and (min-width: $small-screen-max) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -153,12 +153,13 @@ input {
     }
 
     @media only screen and (max-width: $small-screen-max) {
-      min-width: 50%;
+      width: 50%;
       margin-top: $base-spacing / 2;
     }
   }
 
   @media only screen and (max-width: $small-screen-max) {
     @include flex-wrap(wrap);
+    @include flex-direction(column);
   }
 }

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -131,10 +131,22 @@ input {
 
 // Full-width field
 
-.input--large {
-  width: $large-input-width;
-}
+.fieldset--large {
+  @include display(flex);
+  @include flex-wrap(nowrap);
 
+  &__input {
+    width: $large-input-width;
+    @include flex-grow(1);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &__button.button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
 
 // Button is #09A0DB, hover #6BC6E9
 // Button copy is 16 px #ffffff Lato bold

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -146,6 +146,8 @@ input {
   }
 
   &__button.button {
+    min-width: 117px; // Safari won't make the button wide enough to fit text and padding
+
     @media only screen and (min-width: $small-screen-max) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -136,17 +136,30 @@ input {
   @include flex-wrap(nowrap);
 
   &__input {
-    width: $large-input-width;
     @include flex-grow(1);
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    width: $large-input-width;
+
+    @media only screen and (min-width: $small-screen-max) {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   &__button.button {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    box-shadow: $base-box-shadow;
+
+    @media only screen and (min-width: $small-screen-max) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    @media only screen and (max-width: $small-screen-max) {
+      min-width: 50%;
+      margin-top: $base-spacing / 2;
+    }
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include flex-wrap(wrap);
   }
 }
-
-// Button is #09A0DB, hover #6BC6E9
-// Button copy is 16 px #ffffff Lato bold

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -122,7 +122,7 @@ input {
   padding: $form-input-vertical-padding $form-input-horizontal-padding;
   border: $form-border;
   border-radius: $form-border-radius;
-  box-shadow: inset $base-box-shadow;
+  box-shadow: $form-input-box-shadow;
 
   @include placeholder {
     color: $form-placeholder-color;
@@ -145,6 +145,7 @@ input {
   }
 
   &__button.button {
+    box-shadow: $form-input-box-shadow;
     min-width: 117px; // Safari won't make the button wide enough to fit text and padding
 
     @media only screen and (min-width: $small-screen-max) {

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -1,112 +1,113 @@
-input,
-label,
-select {
-  display: block;
-}
-
-label {
-  margin-bottom: $base-spacing / 4;
-  font-weight: $font-weight-bold;
-
-  &.required:after {
-    // TODO: Make this an icon on an input field, instead
-    content: "*";
-  }
-
-  abbr {
-    display: none;
-  }
-}
-
-textarea,
-#{$all-text-inputs},
-select[multiple=multiple] {
-  @include box-sizing(border-box);
-  @include transition(border-color);
-  background-color: $white;
-  border-radius: $form-border-radius;
-  border: $base-input-border-size solid $form-border-color;
-  box-shadow: $form-box-shadow;
-  font-family: $form-font-family;
-  font-size: $base-input-font-size;
-  line-height: $base-input-line-height;
-  padding: $base-input-vertical-padding $base-input-horizontal-padding;
-  margin-bottom: 3px; // Just enough margin to expose the 'glow'
-
-  &:hover {
-    border-color: $form-border-color-hover;
-  }
-
-  &:focus {
-    border-color: $form-border-color-focus;
-    box-shadow: $form-box-shadow-focus;
-    outline: none;
-  }
-}
-
-textarea {
-  resize: vertical;
-}
-
-input[type="radio"] {
-  @extend %visuallyHidden;
-}
-
-input[type="radio"] + label {
-  position: relative;
-
-  &:before {
-    left: 0;
-    top: 0;
-    content: " ";
-    background-color: $white;
-    box-shadow: $base-radio-box-shadow;
-    padding: $base-font-size;
-    margin-right: $base-spacing / 4;
-    border-radius: $radio-border-radius;
-    float: left;
-    display: inline-block;
-    position: relative;
-  }
-}
-
-input[type="radio"]:hover + label {
-  &:before {
-    box-shadow: $hover-radio-box-shadow;
-    @include transition(box-shadow 0.5s linear);
-  }
-}
-
-input[type="radio"]:checked + label {
-  &:before {
-    box-shadow: $checked-radio-box-shadow;
-  }
-}
-
-input[type="radio"]:active + label {
-  &:before {
-    box-shadow: $active-radio-box-shadow;
-  }
-}
-
-select {
-  margin-bottom: $base-spacing;
-  max-width: 100%;
-  width: auto;
-}
-
-.form-header {
-  color: $header-text-color;
-  display: block;
-  font-weight: bold;
-  margin-bottom: $base-spacing / 4;
-}
-
-div.group {
-  overflow: auto; // Push height even when form elements float
-  margin-top: $base-spacing / 2;
-}
-
-table {
-  @include font-feature-settings("kern", "liga", "tnum");
-}
+// TODO Determine any styles to keep and reactivate
+// input,
+// label,
+// select {
+//   display: block;
+// }
+//
+// label {
+//   margin-bottom: $base-spacing / 4;
+//   font-weight: $font-weight-bold;
+//
+//   &.required:after {
+//     // TODO: Make this an icon on an input field, instead
+//     content: "*";
+//   }
+//
+//   abbr {
+//     display: none;
+//   }
+// }
+//
+// textarea,
+// #{$all-text-inputs},
+// select[multiple=multiple] {
+//   @include box-sizing(border-box);
+//   @include transition(border-color);
+//   background-color: $white;
+//   border-radius: $form-border-radius;
+//   border: $base-input-border-size solid $form-border-color;
+//   box-shadow: $form-box-shadow;
+//   font-family: $form-font-family;
+//   font-size: $base-input-font-size;
+//   line-height: $base-input-line-height;
+//   padding: $base-input-vertical-padding $base-input-horizontal-padding;
+//   margin-bottom: 3px; // Just enough margin to expose the 'glow'
+//
+//   &:hover {
+//     border-color: $form-border-color-hover;
+//   }
+//
+//   &:focus {
+//     border-color: $form-border-color-focus;
+//     box-shadow: $form-box-shadow-focus;
+//     outline: none;
+//   }
+// }
+//
+// textarea {
+//   resize: vertical;
+// }
+//
+// input[type="radio"] {
+//   @extend %visuallyHidden;
+// }
+//
+// input[type="radio"] + label {
+//   position: relative;
+//
+//   &:before {
+//     left: 0;
+//     top: 0;
+//     content: " ";
+//     background-color: $white;
+//     box-shadow: $base-radio-box-shadow;
+//     padding: $base-font-size;
+//     margin-right: $base-spacing / 4;
+//     border-radius: $radio-border-radius;
+//     float: left;
+//     display: inline-block;
+//     position: relative;
+//   }
+// }
+//
+// input[type="radio"]:hover + label {
+//   &:before {
+//     box-shadow: $hover-radio-box-shadow;
+//     @include transition(box-shadow 0.5s linear);
+//   }
+// }
+//
+// input[type="radio"]:checked + label {
+//   &:before {
+//     box-shadow: $checked-radio-box-shadow;
+//   }
+// }
+//
+// input[type="radio"]:active + label {
+//   &:before {
+//     box-shadow: $active-radio-box-shadow;
+//   }
+// }
+//
+// select {
+//   margin-bottom: $base-spacing;
+//   max-width: 100%;
+//   width: auto;
+// }
+//
+// .form-header {
+//   color: $header-text-color;
+//   display: block;
+//   font-weight: bold;
+//   margin-bottom: $base-spacing / 4;
+// }
+//
+// div.group {
+//   overflow: auto; // Push height even when form elements float
+//   margin-top: $base-spacing / 2;
+// }
+//
+// table {
+//   @include font-feature-settings("kern", "liga", "tnum");
+// }

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -137,7 +137,6 @@ input {
 
   &__input {
     @include flex-grow(1);
-    width: $large-input-width;
 
     @media only screen and (min-width: $small-screen-max) {
       border-top-right-radius: 0;

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -111,3 +111,30 @@
 // table {
 //   @include font-feature-settings("kern", "liga", "tnum");
 // }
+
+
+input {
+  font-size: $form-input-font-size;
+  font-family: $form-font-family;
+  font-weight: $form-input-font-weight;
+  background-color: $form-background-color;
+  color: $form-input-color;
+  padding: $form-input-vertical-padding $form-input-horizontal-padding;
+  border: $form-border;
+  border-radius: $form-border-radius;
+  box-shadow: $base-box-shadow;
+
+  @include placeholder {
+    color: $form-placeholder-color;
+  }
+}
+
+// Full-width field
+
+.input--large {
+  width: $large-input-width;
+}
+
+
+// Button is #09A0DB, hover #6BC6E9
+// Button copy is 16 px #ffffff Lato bold

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -6,7 +6,6 @@ $lato: Lato, 'Lato', Helvetica, Arial, sans-serif;
 // Typefaces
 $base-font-family: $lato;
 $header-font-family: $lato;
-$form-font-family: $base-font-family;
 
 // Font Weights
 $font-weight-light: 300;
@@ -121,3 +120,7 @@ cite {
 .heavy {
   font-weight: $font-weight-bold;
 }
+
+// Forms
+$form-font-family: $base-font-family;
+$form-input-font-weight: $font-weight-normal;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -165,7 +165,7 @@ $base-border-primary-color: $grey-light;
 $base-border: 1px solid $base-border-primary-color;
 
 // Forms
-$form-border-color: $grey-semi-dark;
+$form-border-color: $grey;
 $form-border: 1px solid $form-border-color;
 $form-border-color-hover: darken($base-border-primary-color, 10);
 $form-border-color-focus: $alert-primary;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -165,7 +165,7 @@ $base-border-primary-color: $grey-light;
 $base-border: 1px solid $base-border-primary-color;
 
 // Forms
-$form-border-color: $grey;
+$form-border-color: $grey-semi-dark;
 $form-border: 1px solid $form-border-color;
 $form-border-color-hover: darken($base-border-primary-color, 10);
 $form-border-color-focus: $alert-primary;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -35,9 +35,11 @@ $gradient-light: #58A9A2;
 // Basic Colors
 $black: #000000;
 $white: #FFFFFF;
+
 $grey-darkest: lighten($black, 20);
 $grey-darker: lighten($grey-darkest, 20);
 $grey-dark: #999999;
+$grey-semi-dark: #BBBBBB;
 $grey: #CCCCCC;
 $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
@@ -162,7 +164,12 @@ $inactive-carousel-button-color: $grey-lighter;
 $base-border-primary-color: $grey-light;
 $base-border: 1px solid $base-border-primary-color;
 
-// Form
-$form-border-color: $base-border-primary-color;
+// Forms
+$form-border-color: $grey;
+$form-border: 1px solid $form-border-color;
 $form-border-color-hover: darken($base-border-primary-color, 10);
 $form-border-color-focus: $alert-primary;
+
+$form-background-color: $white;
+$form-input-color: $body-text-color;
+$form-placeholder-color: $grey-semi-dark;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -22,6 +22,7 @@ $header-line-height: 1.25;
 
 // Box Shadow
 $base-box-shadow: 0 1px 2px 0 rgba($black, 0.25);
+$form-input-box-shadow: 0 1px 2px 0 rgba($black, 0.1);
 
 // Other Sizes
 // TODO Promote minor-border-radius to base?

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -20,7 +20,11 @@ $caption-font-size: $small-font-size;
 $base-line-height: 1.5;
 $header-line-height: 1.25;
 
+// Box Shadow
+$base-box-shadow: 0 1px 2px 0 rgba($black, 0.25);
+
 // Other Sizes
+// TODO Promote minor-border-radius to base?
 $base-border-radius: 5px;
 $minor-border-radius: 3px;
 $button-border-radius: $minor-border-radius;
@@ -31,7 +35,7 @@ $base-spacing: $base-line-height * 1em;
 $base-z-index: 0;
 
 // Image Sizes
-$image-grid-block: 160px; 
+$image-grid-block: 160px;
 
 // Section Spacing
 $base-bottom-margin: $base-spacing / 2;
@@ -42,21 +46,23 @@ $direction-arrow-size: 2em;
 $close-x-size: 18px;
 
 // Forms
-$form-border-radius: $base-border-radius;
+$form-border-radius: $minor-border-radius;
 $form-box-shadow: inset 0 1px 3px rgba($black, 0.06);
 $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color-focus, 5), 0.7);
-$form-font-size: $base-font-size;
 
 // Input Sizes
-$base-input-font-size: $form-font-size;
-$base-input-vertical-padding: $base-input-font-size * 0.688;
-$base-input-horizontal-padding: $base-input-font-size * 0.625;
+$form-input-font-size: $base-font-size;
+$base-input-font-size: $form-input-font-size;
+$form-input-vertical-padding: $form-input-font-size * 0.59375;
+$form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;
 
-$medium-input-font-size: $base-input-font-size;
-$medium-input-vertical-padding: $base-input-vertical-padding;
-$medium-input-horizontal-padding: $base-input-horizontal-padding;
+$large-input-width: 100%;
+
+$medium-input-font-size: $form-input-font-size;
+$medium-input-vertical-padding: $form-input-vertical-padding;
+$medium-input-horizontal-padding: $form-input-horizontal-padding;
 
 $small-input-font-size: $base-input-font-size * 0.875;
 $small-input-vertical-padding: $base-input-font-size * 0.438;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -53,7 +53,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color
 // Input Sizes
 $form-input-font-size: $base-font-size;
 $base-input-font-size: $form-input-font-size;
-$form-input-vertical-padding: $form-input-font-size * 0.59375;
+$form-input-vertical-padding: $form-input-font-size * 0.6;
 $form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;


### PR DESCRIPTION
- Comments out old form styles which will need to be updated but which were not in use; now importing the forms stylesheet into base.scss
- Updates form styling variables
  - Add `input` styles from [UX style guide](https://app.frontify.com/d/6xYC97AVwz1E/style-guide#/ui-patterns/data-entry) v1
  - Update typography.scss for form font-family and font-weight; add anchor blue color for input text
  - Update sizing.scss with form font sizes and padding
  - Add `$grey-semi-dark` color variable for placeholder text
  - Update form border and border-radius styles
  - Update base and form box shadows
- Adds new `.fieldset--large` styles -- a full-width form input with attached submit button

@kurtedelbrock @toastercup @ElliottAYoung 