### PR TITLE
EM-489: Consistent Homepage Section Spacing

### DIFF
--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -155,7 +155,7 @@ input {
 
     @media only screen and (max-width: $small-screen-max) {
       width: 50%;
-      margin-top: $base-spacing / 2;
+      margin-top: $base-margin;
     }
   }
 

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -25,7 +25,7 @@ h6 {
   color: $header-text-color;
   text-decoration: none;
   margin: 0;
-  margin-bottom: $base-bottom-margin;
+  margin-bottom: $type-margin;
 }
 
 h1,
@@ -60,7 +60,7 @@ h6,
 
 p {
   font-size: $base-font-size;
-  margin-bottom: $base-bottom-margin;
+  margin-bottom: $type-margin;
   line-height: $base-line-height;
 
   &:last-child {

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -32,15 +32,18 @@ $button-border-radius: $minor-border-radius;
 $panel-border-radius: $minor-border-radius;
 $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
-$base-spacing: $base-line-height * 1em;
 $base-z-index: 0;
 
 // Image Sizes
 $image-grid-block: 160px;
 
-// Section Spacing
-$base-bottom-margin: $base-spacing / 2;
-$section--padding: 64px;
+// Spacing
+// TODO Use names like base-spacing-large and base-spacing-medium, a la Bootstrap, after we address spacing beyond the homepage
+$base-spacing: $base-line-height * 1em; // 24px
+$base-margin: $base-spacing / 2; // 12px
+$section-padding: 35px;
+
+$type-margin: 24px;
 
 // UI components
 $direction-arrow-size: 2em;


### PR DESCRIPTION
Created new group of spacing variables:
- `$base-spacing` is unchanged
- `$base-margin` (`$base-spacing / 2`) is unchanged
  - Used for space inside and between boxes
- Created new variable `$type-margin` for headers and paragraphs
   - Set it equal to 24px [per Stephanie Gaspary's comment in Jira](https://cb-content-enablement.atlassian.net/browse/EM-489?focusedCommentId=19000&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19000)
  - Reading pages have styles that overwrite this standard margin, so they are unchanged and they aren't using the 24px margin
  - On Reading pages: paragraph margins = 20px; headline margins vary and are proportional to the size of the headline
- Changed `$section-padding` (used on homepage sections) to 35px. It is independent of base-spacing

@toastercup @ElliottAYoung 