### PR TITLE
EM-524: Z-index

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -17,6 +17,7 @@
 @import "directives/panels";
 @import "directives/speech_bubble";
 @import "directives/visibility";
+@import "directives/z_index";
 
 @import "typography";
 @import "buttons";

--- a/sass/directives/_z_index.scss
+++ b/sass/directives/_z_index.scss
@@ -1,0 +1,18 @@
+@function z($context-list, $context-item, $element-list, $element-item) {
+
+  $big-number: index($context-list, $context-item) * 1000;
+  $little-number: index($element-list, $element-item);
+
+  @if ($big-number and $little-number) {
+    $z-index: $big-number + $little-number;
+    @return $z-index;
+  }
+
+  @warn 'Z-index not calculated \a
+  You chose #{$context-item} from the following "context" list: \a
+  #{$context-list} \a
+  and #{$element-item} from the following "element" list: \a
+  #{$element-list} \a
+  Make sure your list names and your item names are correct.';
+  @return null;
+}

--- a/sass/directives/_z_index.scss
+++ b/sass/directives/_z_index.scss
@@ -1,16 +1,35 @@
-@function z($context-list, $context-item, $element-list, $element-item) {
+// Returns a z-index for a given element-list
 
-  $big-number: index($context-list, $context-item) * 1000;
-  $little-number: index($element-list, $element-item);
+// Create the following lists in your project and pass in as arguments
 
-  @if ($big-number and $little-number) {
-    $z-index: $big-number + $little-number;
+  // $context-group-list - a variable that contains a list of contexts ($context-group) or groups of elements;
+    // e.g. from lowest to highest layer:
+    // $context-group-list: (page-level-context, fixed-navigation-context, popup-modal-context);
+
+  // $element-list - a variable that matches a $context-group from the $context-group-list and that contains a list of elements ($element-item) that are layered within that context;
+    // e.g. from lowest to highest layer:
+    // $fixed-navigation-context: (navigation-bar, navigation-bar-dropdown);
+    // $popup-modal-context: (popup-modal-background, popup-modal-popup);
+
+  // The example elements above will have the following z-index values
+    // navigation-bar - 2001
+    // navigation-bar-dropdown - 2002
+    // popup-modal-background - 3001
+    // popup-modal-popup - 3002
+
+@function z($context-group-list, $context-group, $element-list, $element-item) {
+
+  $context-index: index($context-group-list, $context-group) * 1000;
+  $element-index: index($element-list, $element-item);
+
+  @if ($context-index and $element-index) {
+    $z-index: $context-index + $element-index;
     @return $z-index;
   }
 
   @warn 'Z-index not calculated \a
-  You chose #{$context-item} from the following "context" list: \a
-  #{$context-list} \a
+  You chose #{$context-group} from the following "context" list: \a
+  #{$context-group-list} \a
   and #{$element-item} from the following "element" list: \a
   #{$element-list} \a
   Make sure your list names and your item names are correct.';

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -32,7 +32,6 @@ $button-border-radius: $minor-border-radius;
 $panel-border-radius: $minor-border-radius;
 $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
-$base-z-index: 0;
 
 // Image Sizes
 $image-grid-block: 160px;


### PR DESCRIPTION
@toastercup @ElliottAYoung 

* Adds Sass formula that returns an appropriate relative `z-index` value given certain inputs
  * _Are the comments clear?_
  * The formula prints an error if the arguments are wrong and the z-index property is just omitted so the site doesn't break. I'm undecided - it might be more clear if the site breaks and uses the native Rails errors

* The formula is a bit complex in that you have to create the lists for the 4 arguments, but it's an improvement in that we'll no longer have to determine our own z-index numbers given all of the layered elements on the site. We just list things in the order in which they should be layered and it's much more flexible.

* Removed `$base-z-index` variable because it was set to equal 0 and anything that needs to be explicitly set to 0 should be clear and use "0". The variable wasn't in use in Employer
