### PR TITLE
Speech bubble

### DIFF
--- a/sass/_boxes.scss
+++ b/sass/_boxes.scss
@@ -5,11 +5,11 @@
   padding-bottom: 15px;
   background-color: white;
   border-bottom: $base-border;
-  box-shadow: $component-box-shadow;
+  box-shadow: $base-box-shadow;
   border-radius: $minor-border-radius;
 
   &:hover {
-    box-shadow: $component-box-shadow-hover;
+    box-shadow: $base-box-shadow-hover;
 
     .color_strip {
       height: $small-strip-height + 0.1rem;

--- a/sass/directives/_speech_bubble.scss
+++ b/sass/directives/_speech_bubble.scss
@@ -1,4 +1,5 @@
 @mixin speech_bubble {
+  border: $base-border;
   border-radius: $base-border-radius;
   padding: $base-spacing / 2 $base-spacing;
 

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -22,6 +22,7 @@ $header-line-height: 1.25;
 
 // Box Shadow
 $base-box-shadow: 0 1px 2px 0 rgba($black, 0.25);
+$base-box-shadow-hover: 0px 5px 10px rgba($black,.15);
 $form-input-box-shadow: 0 1px 2px 0 rgba($black, 0.1);
 
 // Other Sizes


### PR DESCRIPTION
- Add `$base-box-shadow-hover`
- Use `$base-box-shadow` and `$base-box-shadow-hover` -- which are defined here instead of in [Employer](https://github.com/cbdr/employer) -- in `sass/_boxes.scss`
- Add `border` to `speech_bubble` mixin since all current speech bubble instances use the same `border` style

@toastercup @ElliottAYoung