### PR TITLE
EM582: Hero Headers and Forms

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -2,7 +2,7 @@
 @import "variables/breakpoints.scss";
 @import "variables/colors";
 @import "variables/sizing";
-@import "variables/motion";
+@import "variables/animations";
 
 // SASS Directives
 @import "directives/accents";

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -14,6 +14,7 @@
 @import "directives/flashes";
 @import "directives/gradients";
 @import "directives/groups";
+@import "directives/headers";
 @import "directives/link";
 @import "directives/modals";
 @import "directives/speech_bubble";

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -204,7 +204,14 @@ form button {
     }
   }
 
-  label,
+  label {
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: $grey-lighter;
+    }
+  }
+
   input[type='radio']:checked + label {
     &:hover,
     &:active,
@@ -231,21 +238,30 @@ form button {
 
   input[type="search"]:focus {
     border: 1px solid $sky-blue;
-    outline: 1px solid $sky-blue;
+    outline: 0;
   }
 
   ul {
     position: absolute;
     width: 100%;
-    border: 1px solid $sky-blue;
-    border-top: 0;
     background-color: $white;
+    z-index: 1;
   }
 
   li {
     list-style-type: none;
+    border-left: 1px solid $sky-blue;
+    border-right: 1px solid $sky-blue;
+  }
+
+  .eac-item {
     padding: $form-input-vertical-padding $form-input-horizontal-padding;
   }
+
+  li:last-child {
+    border-bottom: 1px solid $sky-blue;
+  }
+
   li:hover {
     background-color: $sky-blue;
     color: $white;

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -114,7 +114,8 @@
 
 form h2,
 form p,
-input {
+input[type='text'],
+input[type='select']{
   margin-bottom: $base-margin;
 }
 
@@ -129,7 +130,8 @@ label {
   font-weight: $form-label-font-weight;
 }
 
-input,
+input[type='text'],
+input[type='select'],
 textarea {
   font-size: $form-input-font-size;
   font-family: $form-font-family;
@@ -150,6 +152,18 @@ textarea {
 input[type='submit'],
 form button {
   width: 100%;
+}
+
+// Radio button toggle
+
+@mixin radio-toggle {
+  display: flex;
+  border: $base-border;
+  border-radius: $minor-border-radius;
+
+  input[type="radio"] {
+    box-shadow: none;
+  }
 }
 
 // Full-width field

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -112,14 +112,6 @@
 //   @include font-feature-settings("kern", "liga", "tnum");
 // }
 
-form h2,
-form p,
-input[type='text'],
-input[type='search'],
-input[type='select'] {
-  margin-bottom: $base-margin;
-}
-
 fieldset { // #pardot-form p
   display: block;
   margin-bottom: $form-fieldset-margin;
@@ -131,12 +123,15 @@ label {
   font-weight: $form-label-font-weight;
 }
 
-input[type='text'],
-input[type='select'],
-input[type='search'],
-textarea {
-  width: 100%;
+form h2,
+form p {
+  margin-bottom: $base-margin;
+}
+
+#{$all-text-inputs} {
   box-sizing: border-box;
+  width: 100%;
+  margin-bottom: $base-margin;
   border: $form-border;
   border-radius: $form-border-radius;
   padding: $form-input-vertical-padding $form-input-horizontal-padding;
@@ -274,8 +269,9 @@ form button {
   @include display(flex);
   @include flex-wrap(nowrap);
 
-  &__input {
+  & input {
     @include flex-grow(1);
+    margin-bottom: 0;
 
     @media only screen and (min-width: $small-screen-max) {
       border-top-right-radius: 0;

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -115,7 +115,8 @@
 form h2,
 form p,
 input[type='text'],
-input[type='select']{
+input[type='search'],
+input[type='select'] {
   margin-bottom: $base-margin;
 }
 
@@ -132,17 +133,19 @@ label {
 
 input[type='text'],
 input[type='select'],
+input[type='search'],
 textarea {
-  font-size: $form-input-font-size;
-  font-family: $form-font-family;
-  font-weight: $form-input-font-weight;
-  background-color: $form-background-color;
-  color: $form-input-color;
-  padding: $form-input-vertical-padding $form-input-horizontal-padding;
+  width: 100%;
+  box-sizing: border-box;
   border: $form-border;
   border-radius: $form-border-radius;
+  padding: $form-input-vertical-padding $form-input-horizontal-padding;
   box-shadow: $form-input-box-shadow;
-  width: 100%;
+  background-color: $form-background-color;
+  color: $form-input-color;
+  font-family: $form-font-family;
+  font-size: $form-input-font-size;
+  font-weight: $form-input-font-weight;
 
   @include placeholder {
     color: $form-placeholder-color;
@@ -158,6 +161,7 @@ form button {
 
 @mixin radio-toggle {
   @include display(flex);
+  margin-bottom: $base-margin;
   width: 100%;
 
   input[type='radio'] {

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -112,6 +112,12 @@
 //   @include font-feature-settings("kern", "liga", "tnum");
 // }
 
+form h2,
+form p,
+input {
+  margin-bottom: $base-margin;
+}
+
 fieldset { // #pardot-form p
   display: block;
   margin-bottom: $form-fieldset-margin;
@@ -141,7 +147,8 @@ textarea {
   }
 }
 
-input[type='submit'] {
+input[type='submit'],
+form button {
   width: 100%;
 }
 

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -219,6 +219,39 @@ form button {
   }
 }
 
+// Autocomplete Dropdown
+
+@mixin autocomplete-dropdown {
+  position: relative;
+  margin-bottom: $base-margin;
+
+  input[type="search"] {
+    margin-bottom: 0;
+  }
+
+  input[type="search"]:focus {
+    border: 1px solid $sky-blue;
+    outline: 1px solid $sky-blue;
+  }
+
+  ul {
+    position: absolute;
+    width: 100%;
+    border: 1px solid $sky-blue;
+    border-top: 0;
+    background-color: $white;
+  }
+
+  li {
+    list-style-type: none;
+    padding: $form-input-vertical-padding $form-input-horizontal-padding;
+  }
+  li:hover {
+    background-color: $sky-blue;
+    color: $white;
+  }
+}
+
 // Full-width field
 
 .fieldset--large {

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -157,12 +157,61 @@ form button {
 // Radio button toggle
 
 @mixin radio-toggle {
-  display: flex;
-  border: $base-border;
-  border-radius: $minor-border-radius;
+  @include display(flex);
+  width: 100%;
 
-  input[type="radio"] {
-    box-shadow: none;
+  input[type='radio'] {
+    display: none;
+  }
+
+  label {
+    @include flex(1);
+    margin: 0;
+    border: $base-border;
+    padding: 6px 24px;
+    background-color: $grey-light;
+    cursor: pointer;
+    transition: $toggle-button-transistion;
+
+    &:first-of-type {
+      border-top-left-radius: $minor-border-radius;
+      border-bottom-left-radius: $minor-border-radius;
+    }
+
+    &:last-of-type {
+      border-top-right-radius: $minor-border-radius;
+      border-bottom-right-radius: $minor-border-radius;
+    }
+
+    &:before {
+      content: '\f111';
+      font-family: FontAwesome;
+      margin-right: 6px;
+      color: $white;
+    }
+  }
+
+  input[type='radio']:checked + label {
+    background-color: $white;
+
+    &:before {
+      content: '\f058';
+      color: $base-link-color;
+    }
+  }
+
+  label,
+  input[type='radio']:checked + label {
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: $hover-link-color;
+      color: $white;
+
+      &:before {
+        color: $white;
+      }
+    }
   }
 }
 

--- a/sass/directives/_gradients.scss
+++ b/sass/directives/_gradients.scss
@@ -5,3 +5,11 @@
   background: linear-gradient(135deg, $gradient-dark 0%, $gradient-medium 35%, $gradient-light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$gradient-dark}', endColorstr='#{$gradient-light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
 }
+
+@mixin cbGradientTransparent {
+  background: $gradient-dark; // Old browsers
+  background: -moz-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // FF3.6-15
+  background: -webkit-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // Chrome10-25,Safari5.1-6
+  background: linear-gradient(135deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$gradient-dark}', endColorstr='#{$gradient-light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+}

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -1,0 +1,133 @@
+@mixin header-hero($background-image-large, $background-image-medium: nil) {
+  position: relative;
+  min-height: $header-height-large;
+  overflow: hidden;
+  background-color: $base-background-color;
+  background-image: url(asset_path(#{$background-image-large}));
+  background-size: auto $header-height-large;
+  background-position: right bottom;
+  background-repeat: repeat no-repeat;
+
+  @media only screen and (max-width: $medium-screen-max) {
+    background-image: url(asset_path(#{$background-image-medium}));
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include display(flex);
+    @include align-items(center);
+    background-size: cover;
+  }
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    @include cbGradientTransparent;
+  }
+
+  &__text {
+    @include display(flex);
+    @include flex-direction(column);
+    @include justify-content(center);
+    @include align-items(flex-start);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding-top: $base-margin;
+    padding-bottom: $base-margin;
+
+    @media only screen and (max-width: $small-screen-max) {
+      position: relative;
+    }
+
+    h1 {
+      margin-top: 0;
+      line-height: normal;
+      color: $hero-text-color;
+    }
+
+    p {
+      max-width: 20em;
+      margin-bottom: 0;
+      font-size: $hero-text-size;
+      color: $hero-text-color;
+    }
+  }
+}
+
+@mixin header-hero-product($background-image-large, $background-image-medium: nil) {
+  position: relative;
+  min-height: $header-height-product;
+  overflow: hidden;
+  background-color: $base-background-color;
+  background-image: url(asset_path(#{$background-image-large}));
+  background-size: auto $header-height-product;
+  background-position: right bottom;
+  background-repeat: repeat no-repeat;
+
+  @media only screen and (max-width: $medium-screen-max) {
+    background-image: url(asset_path(#{$background-image-medium}));
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include display(flex);
+    @include align-items(center);
+    min-height: unset;
+    background-image: none;
+  }
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    @include cbGradientTransparent;
+
+    @media only screen and (max-width: $small-screen-max) {
+      @include cbGradient;
+    }
+  }
+
+  &__text {
+    @include display(flex);
+    @include flex-direction(column);
+    @include justify-content(center);
+    @include align-items(flex-start);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding-top: $base-margin;
+    padding-bottom: $base-margin;
+
+    @media only screen and (max-width: $small-screen-max) {
+      position: relative;
+      padding-top: $header-top-bottom-padding;
+      padding-bottom: $header-top-bottom-padding;
+    }
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: $header-headline-bottom-margin;
+      line-height: normal;
+      color: $hero-text-color;
+    }
+
+    p {
+      max-width: 28em;
+      margin-bottom: 0;
+      font-size: $hero-text-size;
+      color: $hero-text-color;
+    }
+  }
+}

--- a/sass/variables/_animations.scss
+++ b/sass/variables/_animations.scss
@@ -2,6 +2,8 @@ $base-transition: all 0.2s ease;
 
 $link-color-transition: color 0.1s linear;
 
+$toggle-button-transistion: all 0.05s ease;
+
 $popup-animation-transition: all 0.8s ease-in-out;
 
 $popup-background-transition: all 0.3s ease-out;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -60,6 +60,7 @@ $body-text-color: $anchor-blue;
 $paragraph-text-color: $grey-darker;
 $header-text-color: $anchor-blue;
 $base-accent-color: $emerald;
+$hero-text-color: $white;
 
 // Links
 $base-link-color: $sky-blue;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,6 +1,5 @@
 // Font Sizes
 $base-font-size: 1em;
-$small-font-size: 13px;
 
 // TODO used in footer copyright and on email form error messages. No guidance in UX style guide. Undecided on whether we need variables
 $text-smaller: 80%;
@@ -13,6 +12,8 @@ $h4-font-size: $base-font-size;
 $h5-font-size: $base-font-size * 0.83;
 $h6-font-size: $base-font-size * 0.67;
 
+$hero-text-size: $text-larger;
+$small-font-size: 13px;
 $subhead-font-size: $base-font-size * 1.5;
 $caption-font-size: $small-font-size;
 
@@ -101,12 +102,18 @@ $massive-button-font-size: $base-button-font-size * 1.8;
 $massive-button-vertical-padding: $base-input-font-size * 0.375;
 $massive-button-horizontal-padding: $base-input-font-size * 2;
 
-// Header
+// Top Bar
 $top-bar--height: 60px;
 $top-bar--height--mobile: 42px;
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 32px;
 $top-bar-font-size: $small-font-size;
+
+// Header
+$header-height-large: 445px;
+$header-height-product: 495px;
+$header-top-bottom-padding: 32px;
+$header-headline-bottom-margin: 15px;
 
 // Form Elements
 $base-radio-box-shadow: 0 0 0 1px $grey inset, 0 0 0 9px $white inset, 0 0 0 10px $grey inset;


### PR DESCRIPTION
- Add Headers mixin
  - Initially had mixin to use for both home page and Jobs/product page(s), but there were enough minor differences that designers/POs wanted between the two header types so I made two mixins. I need to determine the things that all headers will have in common, extract that and refactor these
-  Form updates
  - common margins for form elements
  - `box-sixing: border-box` so that our padding doesn't make boxes too large
  - Extracted non-text input CSS selectors (like `input[type="button"]`) from text input CSS selectors (like `input[type="search"]` and `input[type="email"]`) and am now using's Bourbon's `$all-text-inputs` variable for styling text inputs
-  Add `radio-toggle` and `autocomplete-dropdown` mixins
-  Rename `motion.scss` to `animation.scss` and add toggle button transition

@toastercup @ElliottAYoung