### PR TITLE
Add white-space property for line breaks on Accordions

### DIFF
--- a/sass/directives/_accordion.scss
+++ b/sass/directives/_accordion.scss
@@ -34,6 +34,7 @@
     border-radius: 0px;
     font-size: $h3-font-size;
     vertical-align: middle;
+    white-space: normal;
 
     &:hover {
       color: $base-link-color;


### PR DESCRIPTION
@arelia @toastercup

Adds the `white-space: normal` property to Accordions so that the text will break (line-break) on mobile