### PR TITLE
Fixup: Add Position Releative to Popup-Modal

### DIFF
--- a/sass/directives/_modals.scss
+++ b/sass/directives/_modals.scss
@@ -1,4 +1,5 @@
 %popup-modal {
+  position: relative;
   width: 90vw;
   height: 90vh;
   max-width: 900px;


### PR DESCRIPTION
Puts the close button in the right position. Can't figure out how that was working without it on other popups.