### PR TITLE
EM-666: Tables and Tooltips (Jobs Compare Chart)

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -21,12 +21,12 @@
 @import "directives/modals";
 @import "directives/speech_bubble";
 @import "directives/tables";
+@import "directives/tooltips";
 @import "directives/visibility";
 @import "directives/z_index";
 
 @import "typography";
 @import "buttons";
-@import "tooltips";
 
 @import "content_grids";
 @import "forms";

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -26,9 +26,11 @@
 
 @import "typography";
 @import "buttons";
+@import "tooltips";
 
-@import "forms";
 @import "content_grids";
+@import "forms";
+@import "tables";
 
 .employer-scope {
   // Reset

--- a/sass/_tables.scss
+++ b/sass/_tables.scss
@@ -1,0 +1,3 @@
+.table-data-icon {
+  @include table-data-icon;
+}

--- a/sass/_tooltips.scss
+++ b/sass/_tooltips.scss
@@ -16,7 +16,11 @@
   &:active .tooltip-contents {
     $tooltip-z-index: 1 !default;
 
-    @include speech_bubble;
+    border: $base-border;
+    border-radius: $base-border-radius;
+    padding: $base-spacing / 2 $base-spacing;
+    background-color: $panel-primary;
+
     padding-top: calc(0.75rem + #{$small-strip-height});
     display: block;
     position: absolute;
@@ -40,11 +44,11 @@
       position: absolute;
       top: 50%;
       right: calc(100% - 5px);
-      transform: translateY(-50%) rotate(-90deg) scaleX(1.65);
+      transform: translateY(-50%) rotate(-90deg) scaleX(1.75);
       text-shadow:
         0 2px 0px rgba(255,255,255, 1),
         0 -1px 2px rgba(0, 0, 0, 0.25);
-      font-size: 30px;
+      font-size: 24px;
       color: $white;
     }
   }

--- a/sass/_tooltips.scss
+++ b/sass/_tooltips.scss
@@ -14,11 +14,13 @@
   &:hover .tooltip-contents,
   &:focus .tooltip-contents,
   &:active .tooltip-contents {
+    $tooltip-z-index: 1 !default;
+
     @include speech_bubble;
     padding-top: calc(0.75rem + #{$small-strip-height});
     display: block;
     position: absolute;
-    z-index: z($z-context, page_content, $page_content, table_tooltip);
+    z-index: $tooltip-z-index;
     width: 40ch;
     left: calc(100% + #{$base-padding});
     top: 50%;

--- a/sass/_tooltips.scss
+++ b/sass/_tooltips.scss
@@ -1,0 +1,49 @@
+.tooltip {
+  position: relative;
+
+  &:before {
+    content: '\f059'; // Question circle icon
+    font-family: FontAwesome;
+    color: $base-link-color;
+  }
+
+  .tooltip-contents {
+    display: none;
+  }
+
+  &:hover .tooltip-contents,
+  &:focus .tooltip-contents,
+  &:active .tooltip-contents {
+    @include speech_bubble;
+    padding-top: calc(0.75rem + #{$small-strip-height});
+    display: block;
+    position: absolute;
+    z-index: z($z-context, page_content, $page_content, table_tooltip);
+    width: 40ch;
+    left: calc(100% + #{$base-padding});
+    top: 50%;
+    transform: translateY(-50%);
+    box-shadow: $base-box-shadow;
+    border: 0;
+    color: $grey-darker;
+    font-size: $tooltip-contents-font-size;
+    font-weight: $font-weight-normal;
+
+    &:before {
+      @include small-strip;
+    }
+
+    &:after {
+      content: '▲';
+      position: absolute;
+      top: 50%;
+      right: calc(100% - 5px);
+      transform: translateY(-50%) rotate(-90deg) scaleX(1.65);
+      text-shadow:
+        0 2px 0px rgba(255,255,255, 1),
+        0 -1px 2px rgba(0, 0, 0, 0.25);
+      font-size: 30px;
+      color: $white;
+    }
+  }
+}

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Lato:300,400,400i,700);
 
 // Typography
 $lato: Lato, 'Lato', Helvetica, Arial, sans-serif;

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -5,8 +5,8 @@
 @mixin small-strip {
   content: '';
   height: $small-strip-height;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-top-right-radius: $minor-border-radius;
+  border-top-left-radius: $minor-border-radius;
   background-color: $anchor-blue;
   position: absolute;
   top: 0;

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -1,3 +1,15 @@
 @mixin shadow($z: 1) {
   box-shadow: 0 (2px * $z) (2px * $z) rgba(0, 0, 0, 0.2);
 }
+
+@mixin small-strip {
+  content: '';
+  height: $small-strip-height;
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  background-color: $anchor-blue;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+}

--- a/sass/directives/_speech_bubble.scss
+++ b/sass/directives/_speech_bubble.scss
@@ -1,13 +1,24 @@
-@mixin speech_bubble($direction: up, $offset-position: left, $base-position: bottom) {
-  $pointer-triangle-size: 28px !default; // width of triangle base
-  $pointer-triangle-foreground-size: $pointer-triangle-size - 1 !default;
-  $pointer-offset: 25% !default;
+@mixin speech_bubble($direction: up, $pointer-offset: 25%, $pointer-triangle-size: 28px) {
+  $pointer-triangle-foreground-size: $pointer-triangle-size - 1;
+  $base-position: null;
+  $offset-position: null;
 
-  // TODO why doesn't this work; gives undefined variable error for both
-  // @if $direction == up {
-  //  $base-position: bottom;
-  //  $offset-position: left;
-  // }
+  @if $direction == up {
+   $base-position: bottom;
+   $offset-position: left;
+  }
+  @if $direction == down {
+   $base-position: top;
+   $offset-position: left;
+  }
+  @if $direction == left {
+   $base-position: right;
+   $offset-position: top;
+  }
+  @if $direction == right {
+   $base-position: left;
+   $offset-position: top;
+  }
 
   border: $base-border;
   border-radius: $base-border-radius;

--- a/sass/directives/_speech_bubble.scss
+++ b/sass/directives/_speech_bubble.scss
@@ -2,6 +2,7 @@
   border: $base-border;
   border-radius: $base-border-radius;
   padding: $base-spacing / 2 $base-spacing;
+  background-color: $panel-primary;
 
   &:after, &:before {
     bottom: 100%;

--- a/sass/directives/_speech_bubble.scss
+++ b/sass/directives/_speech_bubble.scss
@@ -1,31 +1,33 @@
-@mixin speech_bubble {
+@mixin speech_bubble($direction: up, $offset-position: left, $base-position: bottom) {
+  $pointer-triangle-size: 28px !default; // width of triangle base
+  $pointer-triangle-foreground-size: $pointer-triangle-size - 1 !default;
+  $pointer-offset: 25% !default;
+
+  // TODO why doesn't this work; gives undefined variable error for both
+  // @if $direction == up {
+  //  $base-position: bottom;
+  //  $offset-position: left;
+  // }
+
   border: $base-border;
   border-radius: $base-border-radius;
   padding: $base-spacing / 2 $base-spacing;
   background-color: $panel-primary;
 
   &:after, &:before {
-    bottom: 100%;
-    left: 25%;
-    border: solid transparent;
-    content: " ";
-    height: 0;
-    width: 0;
+    content: '';
     position: absolute;
+    #{$base-position}: 100%;
     pointer-events: none;
   }
 
-  &:after {
-    border-color: transparent;
-    border-bottom-color: $header-flyout-color;
-    border-width: 13px;
-    margin-left: -13px;
+  &:before {
+    @include triangle($pointer-triangle-size $pointer-triangle-size/2, $base-border-primary-color, $direction);
+    #{$offset-position}: $pointer-offset;
   }
 
-  &:before {
-    border-color: transparent;
-    border-bottom-color: $base-border-primary-color;
-    border-width: 14px;
-    margin-left: -14px;
+  &:after {
+    @include triangle($pointer-triangle-foreground-size $pointer-triangle-foreground-size/2, $header-flyout-color, $direction);
+    #{$offset-position}: calc(#{$pointer-offset} + 1px);
   }
 }

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -38,10 +38,9 @@
   border-top-right-radius: $table-header-corner-radius;
 }
 
-@mixin table--row-column-headers {
-  $table-highlight-z-index: 1 !default;
-  $table-caption-z-index: 2 !default;
 
+
+@mixin table--row-column-headers($table-highlight-z-index: 1, $table-caption-z-index: 2) {
   border-collapse: separate;
   border-spacing: $table-border-spacing 0;
   table-layout: fixed;

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -56,8 +56,9 @@
   }
 
   th[scope='col'] {
-    text-align: center;
     width: 25%;
+    text-transform: uppercase;
+    text-align: center;
   }
 
   th[scope='row'] {

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -134,6 +134,21 @@
   }
 }
 
+@mixin table--buttons-row {
+  td {
+    background-color: transparent !important;
+    padding-left: 0;
+    padding-right: 0;
+
+    &:hover:after,
+    &:active:after,
+    &:focus:after {
+      content: none !important;
+      display: none;
+    }
+  }
+}
+
 @mixin table-data-icon {
   position: relative;
   right: 9999px;

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -39,6 +39,9 @@
 }
 
 @mixin table--row-column-headers {
+  $table-highlight-z-index: 1 !default;
+  $table-caption-z-index: 2 !default;
+
   border-collapse: separate;
   border-spacing: $table-border-spacing 0;
   table-layout: fixed;
@@ -47,7 +50,7 @@
 
   caption {
     position: relative;
-    z-index: z($z-context, page_content, $page_content, table_caption);
+    z-index: $table-caption-z-index;
     background: $panel-primary;
     text-align: left;
   }
@@ -76,7 +79,7 @@
       top: -5000px;
       height: 10000px;
       width: 100%;
-      z-index: z($z-context, page_content, $page_content, table_highlight);
+      z-index: $table-highlight-z-index;
       pointer-events: none;
     }
   }

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -68,6 +68,7 @@
   th, td {
     padding: $base-padding;
     position: relative;
+    font-size: $small-font-size;
 
     // Column highlight
     &:hover:after,
@@ -98,7 +99,6 @@
   td {
     color: $grey-darker;
     text-align: center;
-    font-size: $small-font-size;
   }
 
   thead {
@@ -135,7 +135,7 @@
   }
 }
 
-@mixin table--buttons-row {
+@mixin table__buttons-row {
   td {
     background-color: transparent !important;
     padding-left: 0;

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -37,3 +37,120 @@
   @include table__header($columns);
   border-top-right-radius: $table-header-corner-radius;
 }
+
+@mixin table--row-column-headers {
+  border-collapse: separate;
+  border-spacing: $table-border-spacing 0;
+  table-layout: fixed;
+  width: 100%;
+  overflow: hidden;
+
+  caption {
+    position: relative;
+    z-index: z($z-context, page_content, $page_content, table_caption);
+    background: $panel-primary;
+    text-align: left;
+  }
+
+  th[scope='col'] {
+    text-align: center;
+    width: 25%;
+  }
+
+  th[scope='row'] {
+    text-align: left;
+  }
+
+  th, td {
+    padding: $base-padding;
+    position: relative;
+
+    // Column highlight
+    &:hover:after,
+    &:active:after,
+    &:focus:after {
+      content: '';
+      position: absolute;
+      background-color: rgba($grey-darkest, 0.1);
+      left: 0;
+      top: -5000px;
+      height: 10000px;
+      width: 100%;
+      z-index: z($z-context, page_content, $page_content, table_highlight);
+      pointer-events: none;
+    }
+  }
+
+  // Remove column highlight
+  th[scope='row'],
+  thead td {
+    &:hover:after,
+    &:active:after,
+    &:focus:after {
+      content: none;
+    }
+  }
+
+  td {
+    color: $grey-darker;
+    text-align: center;
+    font-size: $small-font-size;
+  }
+
+  thead {
+    th {
+      color: $white;
+      font-weight: $font-weight-bold;
+    }
+
+    th:nth-of-type(1n) {
+      background-color: $table-column-heading-1;
+    }
+
+    th:nth-of-type(2n) {
+      background-color: $table-column-heading-2;
+    }
+
+    th:nth-of-type(3n) {
+      background-color: $table-column-heading-3;
+    }
+  }
+
+  tbody {
+    tr:nth-child(odd) {
+      th, td {
+        background-color: $table-row-light;
+      }
+    }
+
+    tr:nth-child(even) {
+      th, td {
+        background-color: $table-row-dark;
+      }
+    }
+  }
+}
+
+@mixin table-data-icon {
+  position: relative;
+  right: 9999px;
+
+  &:after {
+    position: absolute;
+    top: 50%;
+    right: -9999px;
+    width: 100%;
+    font-size: $table-data-icon-size;
+    line-height: 0;
+    font-family: FontAwesome;
+    color: $grey-dark;
+  }
+
+  &--no:after {
+    content: '\f00d'; // X icon
+  }
+
+  &--yes:after {
+    content: '\f00c'; // Checkmark icon
+  }
+}

--- a/sass/directives/_tooltips.scss
+++ b/sass/directives/_tooltips.scss
@@ -1,4 +1,4 @@
-.tooltip {
+@mixin tooltip($tooltip-z-index: 1) {
   position: relative;
 
   &:before {
@@ -14,8 +14,6 @@
   &:hover .tooltip-contents,
   &:focus .tooltip-contents,
   &:active .tooltip-contents {
-    $tooltip-z-index: 1 !default;
-
     border: $base-border;
     border-radius: $base-border-radius;
     padding: $base-spacing / 2 $base-spacing;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -188,3 +188,9 @@ $form-placeholder-color: $grey-semi-dark;
 // Tables
 $table-row-divider-color: $grey-semi-darker;
 $table-header-background-color: $grey;
+
+$table-row-dark: $grey-light;
+$table-row-light: $grey-lightest;
+$table-column-heading-1: $emerald;
+$table-column-heading-2: $anchor-blue;
+$table-column-heading-3: $sky-blue-light;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -26,6 +26,7 @@ $purple: #662d91;
 
 $azure-two: #1280A1;
 $azure-blue: #287AB9;
+$azure-three: #00A1DE;
 
 // CB Gradient
 $gradient-dark: #0A3A68;
@@ -192,5 +193,5 @@ $table-header-background-color: $grey;
 $table-row-dark: $grey-light;
 $table-row-light: $grey-lightest;
 $table-column-heading-1: $emerald;
-$table-column-heading-2: $anchor-blue;
-$table-column-heading-3: $sky-blue-light;
+$table-column-heading-2: $azure-blue;
+$table-column-heading-3: $azure-three;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -16,6 +16,7 @@ $hero-text-size: $h2-font-size;
 $small-font-size: 13px;
 $subhead-font-size: $base-font-size * 1.5;
 $caption-font-size: $small-font-size;
+$tooltip-contents-font-size: $base-font-size * 0.66375;
 
 // Line height
 $base-line-height: 1.5;
@@ -134,3 +135,6 @@ $table-header-padding: $base-margin;
 $table-header-corner-radius: $minor-border-radius;
 $table-cell-padding-sides: $base-margin;
 $table-cell-padding-top-and-bottom: $base-padding;
+
+$table-data-icon-size: 2em;
+$table-border-spacing: 7.5px;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -35,6 +35,7 @@ $panel-border-radius: $minor-border-radius;
 $radio-border-radius: $base-border-radius * 10;
 $checkbox-border-radius: $panel-border-radius;
 $vertical-rule-width: 1px;
+$small-strip-height: 0.8rem;
 
 // Image Sizes
 $image-grid-block: 160px;


### PR DESCRIPTION
Includes
- Directives for tables with both row and column headers
  - Also adds class for the Yes/No icons in tables
- Directives for tooltips
- Adds Lato italic regular font
- Mixin for `$small-strip`
- Adds parameters to `speech-bubble` mixin for choosing a pointer direction and size

Implemented in [Employer PR #594](https://github.com/cbdr/employer/pull/594)