### PR TITLE
EM-773: Create new variables for 404 Giant Text

### DIFF
--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -12,6 +12,9 @@ $h4-font-size: $base-font-size;
 $h5-font-size: $base-font-size * 0.83;
 $h6-font-size: $base-font-size * 0.67;
 
+$large-header-text: $base-font-size * 8; // 128px
+$large-header-text--mobile: $base-font-size * 4; //64px
+
 $hero-text-size: $h2-font-size;
 $small-font-size: 13px;
 $subhead-font-size: $base-font-size * 1.5;


### PR DESCRIPTION
Adds two new variables for 404 giant header text `$large-header-text` and `$large-header-text--mobile`
Both are computed from the `$base-font-size`