### PR TITLE
EM-665: Jobs Features Section (Read More, Media Elements)

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -30,6 +30,7 @@
 
 @import "content_grids";
 @import "forms";
+@import "read_more";
 @import "tables";
 
 .employer-scope {

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -18,6 +18,7 @@
 @import "directives/groups";
 @import "directives/headers";
 @import "directives/link";
+@import "directives/media";
 @import "directives/modals";
 @import "directives/speech_bubble";
 @import "directives/tables";

--- a/sass/_read_more.scss
+++ b/sass/_read_more.scss
@@ -1,0 +1,53 @@
+/*
+
+Read More Toggle
+
+Works for both inline (nested span) and block (new paragraph) hidden text. Read More and the hidden text have to both be one or the other.
+
+Example Markup:
+
+%p
+  [Visible paragraph]
+  %input#read-more__toggle.read-more__toggle{:type => "checkbox"}
+  %span.read-more__hidden-text [Hidden paragraph, nested]
+  %label.read-more__trigger{:for => "read-more__toggle"}
+    %span.sr-only Toggle paragraph
+
+%p [Visible paragraph]
+%input#read-more__toggle.read-more__toggle{:type => "checkbox"}
+%p.read-more__hidden-text [Hidden paragraph, new block]
+%label.read-more__trigger{:for => "read-more__toggle"}
+  %span.sr-only Toggle paragraph
+
+*/
+
+.read-more__hidden-text {
+  display: none;
+}
+
+.read-more__trigger { // label
+  color: $base-link-color;
+  cursor: pointer;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $hover-link-color;
+  }
+
+  &:after {
+    content: "Read More...";
+  }
+}
+
+.read-more__toggle { // checkbox
+  display: none;
+
+  &:checked ~ .read-more__hidden-text {
+    display: initial;
+  }
+
+  &:checked ~ .read-more__trigger {
+    content: "Read Less...";
+  }
+}

--- a/sass/directives/_media.scss
+++ b/sass/directives/_media.scss
@@ -5,8 +5,9 @@
 
 @mixin media__item ($image-wrap-width, $breakpoint: $small-screen-max) {
   @include display(flex);
-  @include flex(1);
   @include flex-grow(1);
+  @include flex-shrink(1);
+  @include flex-basis(auto);
   margin-bottom: $base-spacing;
 
   &:last-child {

--- a/sass/directives/_media.scss
+++ b/sass/directives/_media.scss
@@ -3,7 +3,7 @@
   @include flex-direction(column);
 }
 
-@mixin media__item {
+@mixin media__item ($image-wrap-width, $breakpoint: $small-screen-max) {
   @include display(flex);
   @include flex(1);
   @include flex-grow(1);
@@ -13,41 +13,41 @@
     margin-bottom: 0;
   }
 
-  @media only screen and (max-width: $small-screen-max) {  // TODO Can this wrap so that I don't have to explicitly set column direction? Give image boxes a min-width?
+  @media only screen and (max-width: $breakpoint) {
     @include flex-direction(column);
     text-align: center;
   }
-}
 
-@mixin media__item__img-wrap($image-wrap-width) {
-  @include flex-grow(0);
-  @include flex-shrink(0);
-  @include flex-basis(auto);
-  width: $image-wrap-width;
-  margin-right: $base-spacing;
-
-  @media only screen and (max-width: $small-screen-max) {
-    width: 100%;
-    margin-right: 0;
-    margin-bottom: $base-margin;
-  }
-}
-
-@mixin media__item__text {
-  @include flex-grow(1);
-  @include flex-shrink(1);
-  @include flex-basis(auto);
-
-  @media only screen and (max-width: $small-screen-max) {
+  &__img-wrap {
+    @include flex-grow(0);
     @include flex-shrink(0);
+    @include flex-basis(auto);
+    width: $image-wrap-width;
+    margin-right: $base-spacing;
+
+    @media only screen and (max-width: $breakpoint) {
+      width: 100%;
+      margin-right: 0;
+      margin-bottom: $base-margin;
+    }
   }
 
-  &--headline {
-    margin-bottom: 0;
-  }
+  &__text {
+    @include flex-grow(1);
+    @include flex-shrink(1);
+    @include flex-basis(auto);
 
-  &--description {
-    font-size: $h3-font-size;
-    color: $paragraph-text-color;
+    @media only screen and (max-width: $breakpoint) {
+      @include flex-shrink(0);
+    }
+
+    &--headline {
+      margin-bottom: 0;
+    }
+
+    &--description {
+      font-size: $h3-font-size;
+      color: $paragraph-text-color;
+    }
   }
 }

--- a/sass/directives/_media.scss
+++ b/sass/directives/_media.scss
@@ -19,10 +19,11 @@
   }
 }
 
-@mixin media__item__img-wrap {
+@mixin media__item__img-wrap($image-wrap-width) {
   @include flex-grow(0);
   @include flex-shrink(0);
   @include flex-basis(auto);
+  width: $image-wrap-width;
   margin-right: $base-spacing;
 
   @media only screen and (max-width: $small-screen-max) {
@@ -35,7 +36,11 @@
 @mixin media__item__text {
   @include flex-grow(1);
   @include flex-shrink(1);
-  @include flex-basis(100%);
+  @include flex-basis(auto);
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include flex-shrink(0);
+  }
 
   &--headline {
     margin-bottom: 0;

--- a/sass/directives/_media.scss
+++ b/sass/directives/_media.scss
@@ -1,0 +1,48 @@
+@mixin media__wrapper {
+  @include display(flex);
+  @include flex-direction(column);
+}
+
+@mixin media__item {
+  @include display(flex);
+  @include flex(1);
+  @include flex-grow(1);
+  margin-bottom: $base-spacing;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  @media only screen and (max-width: $small-screen-max) {  // TODO Can this wrap so that I don't have to explicitly set column direction? Give image boxes a min-width?
+    @include flex-direction(column);
+    text-align: center;
+  }
+}
+
+@mixin media__item__img-wrap {
+  @include flex-grow(0);
+  @include flex-shrink(0);
+  @include flex-basis(auto);
+  margin-right: $base-spacing;
+
+  @media only screen and (max-width: $small-screen-max) {
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: $base-margin;
+  }
+}
+
+@mixin media__item__text {
+  @include flex-grow(1);
+  @include flex-shrink(1);
+  @include flex-basis(100%);
+
+  &--headline {
+    margin-bottom: 0;
+  }
+
+  &--description {
+    font-size: $h3-font-size;
+    color: $paragraph-text-color;
+  }
+}

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -37,8 +37,8 @@ $gradient-light: #58A9A2;
 $black: #000000;
 $white: #FFFFFF;
 
-$grey-darkest: lighten($black, 20);
-$grey-darker: lighten($grey-darkest, 20);
+$grey-darkest: lighten($black, 20); // #333
+$grey-darker: lighten($grey-darkest, 20); /// #666
 $grey-dark: #999999;
 $grey-semi-dark: #BBBBBB;
 $grey-semi-darker: #b0b0b0; // Possibly not part of official style guide

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -162,9 +162,7 @@ $inactive-tab-color: $anchor-blue-light;
 
 // Carousel
 $active-carousel-button-color: $grey-darker;
-$inactive-carousel-button-color: $grey-lighter;
-$active-resource-carousel-button-color: $active-carousel-button-color;
-$inactive-resource-carousel-button-color: $grey;
+$inactive-carousel-button-color: $grey;
 $inactive-carousel-button-opacity: 1;
 $active-carousel-button-opacity: 1;
 $inverse-active-carousel-button-color: $grey-lighter;


### PR DESCRIPTION
Implemented by Employer [#612](https://github.com/cbdr/employer/pull/612) and includes:
 - Read More Toggle classes
   - Made `read-more` mixin based on [PR578](https://github.com/cbdr/employer/pull/578). Turns out I didn’t need to, but now we have it.
   - Read more uses classes instead of mixins because the toggle/checkbox uses the adjacent sibling selector >> so the classes need to refer to each other >> so the classes need to be static
   - On `read-more__trigger` I'm not using the following which shows all text on desktop and only uses toggle on mobile b/c I thought it would be specific to APS and not all read mores (b/c i didn't need it in the Jobs Features read more, but then I realized that Jobs Feature read more is just a link not a toggle). When we eventually add more read mores we may determine that we need to add this
```
  @media only screen and (min-width: $small-screen-max) {
    display: none;
  }
```

-  Add mixins for `media` elements
- Remove resource-carousel button colors and make standard-carousel buttons darker