### PR TITLE
EM-754: Add medium-screen-left-column Mixin

### DIFF
--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -172,3 +172,10 @@
     content: '\f00c'; // Checkmark icon
   }
 }
+
+// Resize leftmost columns on medium screens
+@mixin medium-screen-left-column {
+  @media only screen and (max-width: $medium-screen-max) {
+    width: 14ch;
+  }
+}


### PR DESCRIPTION
@arelia @toastercup

Adds the `medium-screen-left-column` mixin to be used by Employer for the compare chart tables