### PR TITLE
EM-850: Updated Nav Breakpoints For Top Nav User Icon

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -14,6 +14,7 @@
 @import "directives/clearfix";
 @import "directives/ellipsis";
 @import "directives/flashes";
+@import "directives/flyout";
 @import "directives/gradients";
 @import "directives/groups";
 @import "directives/headers";

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -1,26 +1,55 @@
-@mixin nav_flyout($offset: 25%) {
-  @include speech_bubble($pointer-offset: $offset);
-  @include transition($base-transition);
-  position: absolute;
-  text-align: left;
-  z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
-  width: auto;
-  height: auto;
-  padding: 25px;
-  display: none;
+@mixin nav_flyout($top, $left, $offset: 25%) {
+  position: relative;
 
-  @media only screen and (max-width: $mobile-nav-max) {
-    position: relative;
-    top: 0;
-    left: 0;
-    border: 0;
-    border-radius: 0;
-    padding: 0;
-  }
+  ul {
+    @include speech_bubble($pointer-offset: $offset);
+    @include transition($base-transition);
+    position: absolute;
+    top: $top;
+    left: $left;
+    text-align: left;
+    z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
+    width: auto;
+    height: auto;
+    padding: 25px;
+    display: none;
 
-  &:after, &:before {
+
     @media only screen and (max-width: $mobile-nav-max) {
-      content: none;
+      position: relative;
+      top: 0;
+      left: 0;
+      border: 0;
+      border-radius: 0;
+      padding: 0;
+    }
+
+    &:after, &:before {
+      @media only screen and (max-width: $mobile-nav-max) {
+        content: none;
+      }
     }
   }
+
+  ul li {
+    padding: 7px 10px;
+    display: block;
+  }
+
+  ul li a {
+    color: $base-link-color;
+    font-weight: $font-weight-normal;
+
+    &.top-bar__link:hover,
+    &:hover .top-bar__link {
+      text-decoration: underline;
+    }
+
+    @media only screen and (max-width: $mobile-nav-max) {
+      color: $base-link-color;
+      text-indent: 2em;
+    }
+  }
+
+
 }

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -1,0 +1,26 @@
+@mixin nav_flyout($offset: 25%) {
+  @include speech_bubble($pointer-offset: $offset);
+  @include transition($base-transition);
+  position: absolute;
+  text-align: left;
+  z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
+  width: auto;
+  height: auto;
+  padding: 25px;
+  display: none;
+
+  @media only screen and (max-width: $mobile-nav-max) {
+    position: relative;
+    top: 0;
+    left: 0;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  &:after, &:before {
+    @media only screen and (max-width: $mobile-nav-max) {
+      content: none;
+    }
+  }
+}

--- a/sass/variables/_breakpoints.scss
+++ b/sass/variables/_breakpoints.scss
@@ -7,5 +7,5 @@ $medium-screen-max: 64em; // (1024px)
 $large-screen-min: $medium-screen-max;
 
 // Nav breakpoints
-$midrange-nav-max: 71.875em; // (1150px) Point at which full nav no longer fits in one line
-$mobile-nav-max: 60.75em; // (972px) Point at which full nav + collapsed right-side nav no longer fit in one line
+$midrange-nav-max: 88.5em; // (1408px) Point at which full nav no longer fits in one line
+$mobile-nav-max: 66.5em; // (1064px) Point at which full nav + collapsed right-side nav no longer fit in one line

--- a/sass/variables/_breakpoints.scss
+++ b/sass/variables/_breakpoints.scss
@@ -7,5 +7,5 @@ $medium-screen-max: 64em; // (1024px)
 $large-screen-min: $medium-screen-max;
 
 // Nav breakpoints
-$midrange-nav-max: 88.5em; // (1408px) Point at which full nav no longer fits in one line
-$mobile-nav-max: 66.5em; // (1064px) Point at which full nav + collapsed right-side nav no longer fit in one line
+$midrange-nav-max: 71.875em; // (1150px) Point at which full nav no longer fits in one line
+$mobile-nav-max: 60.75em; // (972px) Point at which full nav + collapsed right-side nav no longer fit in one line

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -53,6 +53,7 @@ $base-padding: $base-spacing;
 $section-padding: 35px;
 
 $type-margin: 24px;
+$type-indent: 2em;
 
 // UI components
 $medium-icon-font-size: 25px;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -48,6 +48,7 @@ $image-grid-block: 160px;
 // TODO Use names like base-spacing-large and base-spacing-medium, a la Bootstrap, after we address spacing beyond the homepage
 $base-spacing: $base-line-height * 1rem; // 24px
 $base-margin: $base-spacing / 2; // 12px
+$base-margin--small: $base-margin / 2; // 6px
 $base-padding: $base-spacing;
 $section-padding: 35px;
 


### PR DESCRIPTION
![post jobs and find talent careerbuilder for employers 2017-01-25 11-37-12](https://cloud.githubusercontent.com/assets/10361180/22302020/b8f7bf5e-e2f2-11e6-879a-9e925992cabe.png)

I change the top-nav break-points to account for the extra space the new user account widget takes up.