### PR TITLE
EM-849: Fix Box Styles

### DIFF
--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -1,6 +1,6 @@
-@mixin shadow($z: 1) {
-  box-shadow: 0 (2px * $z) (2px * $z) rgba(0, 0, 0, 0.2);
-}
+// @mixin shadow($z: 1) {
+//   box-shadow: 0 (2px * $z) (2px * $z) rgba(0, 0, 0, 0.2);
+// }
 
 @mixin small-strip {
   content: '';

--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -1,13 +1,11 @@
-// Pop-out Box
-@mixin box--pop-out {
+// Component Box
+@mixin box--component {
   display: block;
-  margin: $base-margin;
-  border: $base-border;
-  border-bottom-width: 3px;
-  @include border-top-radius($minor-border-radius);
-  @include border-bottom-radius($minor-border-radius);
+  border-top: $base-border;
+  border-radius: $minor-border-radius;
   padding: $base-padding;
   background-color: $panel-primary;
+  box-shadow: $base-box-shadow;
 }
 
 // Card Deck - Centered - 4 across

--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -1,5 +1,5 @@
 // Component Box
-@mixin box--component {
+@mixin component-box {
   border-radius: $minor-border-radius;
   padding: $base-padding;
   background-color: $panel-primary;
@@ -29,7 +29,7 @@
 // Card Tile
   // Use: Home product category blocks
 @mixin card--tile {
-  @include box--component;
+  @include component-box;
   @include display(flex);
   @include flex-direction(column);
   @include align-items(center);

--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -1,7 +1,5 @@
 // Component Box
 @mixin box--component {
-  display: block;
-  border-top: $base-border;
   border-radius: $minor-border-radius;
   padding: $base-padding;
   background-color: $panel-primary;

--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -29,16 +29,13 @@
 // Card Tile
   // Use: Home product category blocks
 @mixin card--tile {
+  @include box--component;
   @include display(flex);
   @include flex-direction(column);
   @include align-items(center);
   @include flex(1);
   position: relative;
   margin: $base-margin;
-  border: $base-border;
-  border-radius: $minor-border-radius;
-  padding: $base-padding;
-  background-color: $panel-primary;
   text-decoration: none;
 
   &:hover,


### PR DESCRIPTION
- Remove `shadow` mixin in accents.scss b/c we're not using it and it doesn't comply with the style guide
- Update box mixin to match style guide
- Apply `box--component` mixin to `card--title` mixin (used for "home product category blocks")

**Home Product Category Blocks**
![image](https://cloud.githubusercontent.com/assets/2359538/22724406/6bd422aa-ed8b-11e6-8f6c-d9ef150d9e3d.png)

Applied to Employer in [PR#652](https://github.com/cbdr/employer/pull/652)
