### PR TITLE
Switched Out Pop-Out Mixin With Component-Box

### DIFF
--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -6,7 +6,7 @@
 }
 
 @mixin sticky-box($breakpoint: $small-screen-max) {
-  @include box--pop-out;
+  @include component-box;
   box-shadow: $base-box-shadow;
   position: fixed;
 


### PR DESCRIPTION
This is so that employer does not throw any missing mixin errors. 