### PR TITLE
Use rem for Fonts

### DIFF
--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,5 +1,5 @@
 // Font Sizes
-$base-font-size: 1em;
+$base-font-size: 1rem;
 
 // TODO used in footer copyright and on email form error messages. No guidance in UX style guide. Undecided on whether we need variables
 $text-smaller: 80%;


### PR DESCRIPTION
Use `rem`, not `em`, for fonts

Something I thought I'd done already. Ems allow fonts to scale relative to their container. We don't want that. We want our fonts to always match the pre-determined sizes listed at http://cb-talent-development.github.io/employer-style-base/#typography