### PR TITLE
Revert "Use rem for Fonts"

### DIFF
--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -1,5 +1,5 @@
 // Font Sizes
-$base-font-size: 1rem;
+$base-font-size: 1em;
 
 // TODO used in footer copyright and on email form error messages. No guidance in UX style guide. Undecided on whether we need variables
 $text-smaller: 80%;


### PR DESCRIPTION
Reverts cb-talent-development/employer-style-base#66

This change affected more than I anticipated and I didn't see the issues in the Wraith diffs :(

I still want to make this change, but later when I can review diffs more carefully and make a list of things to watch out for -- for instance button padding is calculated using font size so the change resized anything that is a button, including carousel dots:

![image](https://cloud.githubusercontent.com/assets/2359538/23175857/58a78ba4-f826-11e6-9d9b-92bad796edee.png)
