### PR TITLE
EM-939: Add Param to Offset Flyout Left or Right

### DIFF
--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -1,12 +1,12 @@
-@mixin nav_flyout($top, $left, $offset: 25%) {
+@mixin nav_flyout($top, $flyout-offset-value, $flyout-offset-direction: 'left', $nav-pointer-offset: 25%) {
   position: relative;
 
   ul {
-    @include speech_bubble($pointer-offset: $offset);
+    @include speech_bubble($pointer-offset: $nav-pointer-offset);
     @include transition($base-transition);
     position: absolute;
     top: $top;
-    left: $left;
+    #{$flyout-offset-direction}: $flyout-offset-value;
     text-align: left;
     z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
     width: auto;


### PR DESCRIPTION
Secondary nav flyout needs to be positioned from right b/c when the user name changes it affects how far from the left the flyout needs to move, but from the right the positioning is consistent

Implemented in [Employer PR #670](https://github.com/cbdr/employer/pull/670)

![image](https://cloud.githubusercontent.com/assets/2359538/23202848/91cd86d4-f8a5-11e6-8d97-f9280211d620.png)
