### PR TITLE
EM-939: Refactor .fieldset--large

### DIFF
--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -351,7 +351,10 @@ form button {
 
   &__button.button {
     box-shadow: $form-input-box-shadow;
-    min-width: 117px; // Safari won't make the button wide enough to fit text and padding
+    width: auto;
+    @include flex-grow(0);
+    @include flex-shrink(0);
+    @include flex-basis(auto);
 
     @media only screen and (min-width: $small-screen-max) {
       border-top-left-radius: 0;
@@ -359,7 +362,7 @@ form button {
     }
 
     @media only screen and (max-width: $small-screen-max) {
-      width: 50%;
+      min-width: 50%;
       margin-top: $base-margin;
     }
   }

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -338,6 +338,9 @@ form button {
   & select,
   & .select {
     @include flex-grow(1);
+    @include flex-shrink(1);
+    @include flex-basis(auto);
+    width: 100%;
     margin-bottom: 0;
 
     @media only screen and (min-width: $small-screen-max) {


### PR DESCRIPTION
**Purpose:**
In a field-and-button-combined form field, like the email subscribe form, this changes the way the field and button determine their widths
* Field can now shrink, but it targets 100%, thus taking up as much space as is available, but not so much that the button doesn't fit
* Button sizes it self according to the amount of text it has, and doesn't shrink or grow
* On small screens, button is at least 50% of the screen size, per the original build of the email subscribe form, but button width is auto so that if it needs to be bigger than 50% width to fit it's text it grows to the size it needs

**JIRA:**
Stems from but is independent of [EM-939](https://cb-content-enablement.atlassian.net/browse/EM-939)

**Changes:**
* Changes to setup, Architectural changes, Migrations
  * n/a
  
* Library changes
  * will bump the patch version number of the style-base library

* Side effects
  * should have none; the email subscribe field should appear unchanged. It does help the new fields in [EM-939](https://cb-content-enablement.atlassian.net/browse/EM-939) size properly

**Screenshots**
* Before (left) After (right)

![image](https://cloud.githubusercontent.com/assets/2359538/23519647/4bd9ba0a-ff3d-11e6-8ee3-7b9133131d57.png)

![image](https://cloud.githubusercontent.com/assets/2359538/23519678/62b719b6-ff3d-11e6-801c-a47138957c94.png)


**QA Links:**

none - point your local `bower.json` to this branch

**How to Verify These Changes**
* Specific pages to visit (verify that none of the following is affected):
  * Email Subscribe in footer: any page
  * Jobs Buy Box: /recruitment-advertising/post-job-right-now
  * Search Buy Box: /talentstream/sourcing-technology/resume-database

* Steps to take
  * squish the page to view the forms at different breakpoints
  * maybe add more text to the button

![image](https://cloud.githubusercontent.com/assets/2359538/23519927/5c3db5b2-ff3e-11e6-8b7d-9b9b93009ee9.png)

* Responsive considerations
  * email subscription form field should be as wide as possible on mid and large screens with room for the attached button; on small screen field is 100% wide and button should sit below it sized at least 50% the width of the screen


**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/688

**Additional Information**