### PR TITLE
EM-724: Modernizing Homepage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "authors": [
     "Content Enablement <ContentEnablementProductTeam@careerbuilder.com>"
   ],

--- a/sass/directives/_boxes.scss
+++ b/sass/directives/_boxes.scss
@@ -78,7 +78,7 @@
   }
 }
 
-//Ecom Table Boxes
+// Ecom Table Boxes
 @mixin ecom_table-item {
   border-bottom: $base-border;
   margin-top: $base-margin * 2;
@@ -144,6 +144,52 @@
 
     a {
       width: 100%;
+    }
+  }
+}
+
+// Item Bar
+
+@mixin item-bar__list {
+  @include display(flex);
+  @include justify-content(center);
+  padding: $base-padding 0;
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include flex-direction(column);
+    padding: 0;
+  }
+}
+
+@mixin item-bar__list-item {
+  position: relative;
+  border-right: $base-border;
+  padding: 0 $base-padding;
+  text-align: center;
+  list-style-type: none;
+
+  @media only screen and (max-width: $small-screen-max) {
+    border-right: 0;
+    padding: $base-margin 0;
+
+    &:after {
+      content: '';
+      height: 1px;
+      width: 100px;
+      border-bottom: $base-border;
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
+
+  &:last-child {
+    border: 0;
+
+    &:after {
+      content: none;
+      display: none;
     }
   }
 }

--- a/sass/directives/_gradients.scss
+++ b/sass/directives/_gradients.scss
@@ -22,6 +22,10 @@
   @include gradientTransparent;
 }
 
-@mixin whiteGradientTransparent {
-  @include gradientTransparent($white, #f0f0f0, #f0f0f0);
+@mixin whiteGradientTransparent($dark: $white, $medium: #f0f0f0, $light: #f0f0f0) {
+  background: $dark; // Old browsers
+  background: -moz-linear-gradient(-45deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // FF3.6-15
+  background: -webkit-linear-gradient(-45deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // Chrome10-25,Safari5.1-6
+  background: linear-gradient(135deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
 }

--- a/sass/directives/_gradients.scss
+++ b/sass/directives/_gradients.scss
@@ -1,15 +1,27 @@
+@mixin gradient($dark: $gradient-dark, $medium: $gradient-medium, $light: $gradient-light) {
+  background: $dark; // Old browsers
+  background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // FF3.6-15
+  background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // Chrome10-25,Safari5.1-6
+  background: linear-gradient(135deg, $dark 0%, $medium 35%, $light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+}
+
+@mixin gradientTransparent($dark: $gradient-dark, $medium: $gradient-medium, $light: $gradient-light) {
+  background: $dark; // Old browsers
+  background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, 0.9) 100%); // FF3.6-15
+  background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, 0.9) 100%); // Chrome10-25,Safari5.1-6
+  background: linear-gradient(135deg, $dark 0%, $medium 35%, transparentize($light, 0.9) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+}
+
 @mixin cbGradient {
-  background: $gradient-dark; // Old browsers
-  background: -moz-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, $gradient-light 100%); // FF3.6-15
-  background: -webkit-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, $gradient-light 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient(135deg, $gradient-dark 0%, $gradient-medium 35%, $gradient-light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$gradient-dark}', endColorstr='#{$gradient-light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+  @include gradient;
 }
 
 @mixin cbGradientTransparent {
-  background: $gradient-dark; // Old browsers
-  background: -moz-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // FF3.6-15
-  background: -webkit-linear-gradient(-45deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient(135deg, $gradient-dark 0%, $gradient-medium 35%, transparentize($gradient-light, 0.9) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$gradient-dark}', endColorstr='#{$gradient-light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+  @include gradientTransparent;
+}
+
+@mixin whiteGradientTransparent {
+  @include gradientTransparent($white, #f0f0f0, #f0f0f0);
 }

--- a/sass/directives/_gradients.scss
+++ b/sass/directives/_gradients.scss
@@ -24,8 +24,8 @@
 
 @mixin whiteGradientTransparent($dark: $white, $medium: #f0f0f0, $light: #f0f0f0) {
   background: $dark; // Old browsers
-  background: -moz-linear-gradient(-45deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // FF3.6-15
-  background: -webkit-linear-gradient(-45deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient(135deg, transparentize($dark, 0.1) 0%, transparentize($medium, 0.2) 35%, transparentize($light, 0.85) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, 0.85) 100%); // FF3.6-15
+  background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, 0.85) 100%); // Chrome10-25,Safari5.1-6
+  background: linear-gradient(135deg, $dark 0%, $medium 35%, transparentize($light, 0.85) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
 }

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -49,13 +49,13 @@
     h1 {
       margin-top: 0;
       line-height: normal;
-      color: $hero-text-color;
+      color: $hero-text-color-dark;
     }
 
     p {
       margin-bottom: 0;
       font-size: $hero-text-size;
-      color: $hero-text-color;
+      color: $hero-text-color-dark;
     }
   }
 }

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -138,3 +138,67 @@
     }
   }
 }
+
+@mixin header-hero($background-image-large, $background-image-medium: nil) {
+  position: relative;
+  min-height: $header-height-large;
+  overflow: hidden;
+  background-color: $base-background-color;
+  background-image: url(asset_path(#{$background-image-large}));
+  background-size: auto $header-height-large;
+  background-position: right bottom;
+  background-repeat: repeat no-repeat;
+
+  @media only screen and (max-width: $medium-screen-max) {
+    background-image: url(asset_path(#{$background-image-medium}));
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    @include display(flex);
+    @include align-items(center);
+    background-size: cover;
+  }
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    @include cbGradientTransparent;
+  }
+
+  &__text {
+    @include display(flex);
+    @include flex-direction(column);
+    @include justify-content(center);
+    @include align-items(flex-start);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding-top: $base-margin;
+    padding-bottom: $base-margin;
+
+    @media only screen and (max-width: $small-screen-max) {
+      position: relative;
+    }
+
+    h1 {
+      max-width: 28ch;
+      margin-top: 0;
+      line-height: normal;
+      color: $hero-text-color;
+    }
+
+    p {
+      max-width: 35ch;
+      margin-bottom: 0;
+      font-size: $hero-text-size;
+      color: $hero-text-color;
+    }
+  }
+}

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -1,4 +1,4 @@
-@mixin header-hero($background-image-large, $background-image-medium: nil) {
+@mixin header-hero--home($background-image-large, $background-image-medium: nil) {
   position: relative;
   min-height: $header-height-large;
   overflow: hidden;
@@ -25,7 +25,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    @include cbGradientTransparent;
+    @include whiteGradientTransparent;
   }
 
   &__text {
@@ -47,14 +47,12 @@
     }
 
     h1 {
-      max-width: 28ch;
       margin-top: 0;
       line-height: normal;
       color: $hero-text-color;
     }
 
     p {
-      max-width: 35ch;
       margin-bottom: 0;
       font-size: $hero-text-size;
       color: $hero-text-color;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -64,7 +64,7 @@ $body-text-color: $anchor-blue;
 $paragraph-text-color: $grey-darker;
 $header-text-color: $anchor-blue;
 $base-accent-color: $emerald;
-$hero-text-color: $white;
+$hero-text-color: $anchor-blue;
 
 // Links
 $base-link-color: $sky-blue;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -44,7 +44,6 @@ $grey-dark: #999999;
 $grey-semi-dark: #BBBBBB;
 $grey-semi-darker: #b0b0b0; // Possibly not part of official style guide
 $grey: #CCCCCC;
-$grey-semi-light: #D4D4D4; // top-bar-nav border color
 $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
 $grey-lightest: #F4F4F4;
@@ -64,7 +63,8 @@ $body-text-color: $anchor-blue;
 $paragraph-text-color: $grey-darker;
 $header-text-color: $anchor-blue;
 $base-accent-color: $emerald;
-$hero-text-color: $anchor-blue;
+$hero-text-color: $white;
+$hero-text-color-dark: $anchor-blue;
 
 // Links
 $base-link-color: $sky-blue;
@@ -92,7 +92,6 @@ $header-background-color: $white;
 $header-background-secondary-color: $grey-lighter;
 $header-flyout-color: $header-background-color;
 $header-subtitle-color: $grey-darker;
-$header-border: 1px solid #dfdfdf; // border color per story EM-724
 $footer-background-color: $anchor-blue;
 // $footer-accent-color: $header-accent-color;
 // $footer-text-color: $white;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -44,6 +44,7 @@ $grey-dark: #999999;
 $grey-semi-dark: #BBBBBB;
 $grey-semi-darker: #b0b0b0; // Possibly not part of official style guide
 $grey: #CCCCCC;
+$grey-semi-light: #D4D4D4; // border color
 $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
 $grey-lightest: #F4F4F4;
@@ -178,7 +179,7 @@ $inverse-inactive-carousel-button-opacity: 0.35;
 $inverse-active-carousel-button-opacity: 1;
 
 // Border
-$base-border-primary-color: $grey-light;
+$base-border-primary-color: $grey-semi-light;
 $base-border: 1px solid $base-border-primary-color;
 
 // Forms

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -44,6 +44,7 @@ $grey-dark: #999999;
 $grey-semi-dark: #BBBBBB;
 $grey-semi-darker: #b0b0b0; // Possibly not part of official style guide
 $grey: #CCCCCC;
+$grey-semi-light: #D4D4D4; // top-bar-nav border color
 $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
 $grey-lightest: #F4F4F4;
@@ -91,6 +92,7 @@ $header-background-color: $white;
 $header-background-secondary-color: $grey-lighter;
 $header-flyout-color: $header-background-color;
 $header-subtitle-color: $grey-darker;
+$header-border: 1px solid #dfdfdf; // border color per story EM-724
 $footer-background-color: $anchor-blue;
 // $footer-accent-color: $header-accent-color;
 // $footer-text-color: $white;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -48,6 +48,11 @@ $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
 $grey-lightest: #F4F4F4;
 
+// Brand Simplification - new colors; temporary names
+
+$brand-new-lime: #66a52a;
+$brand-new-azure: #0097d1;
+
 
 // Color Usage
 


### PR DESCRIPTION
Includes Brand Simplification changes (can we omit this from releases?)

**Purpose:**
* Changes for homepage modernization and brand simplification
  * new white gradient mixin
  * new home header styles
  * new colors
  * new mixin for making stats bars

![image](https://cloud.githubusercontent.com/assets/2359538/23541011/48dd4a02-ffaa-11e6-8b95-13f4e55cdc9e.png)

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-724

**Changes:**
* Changes to setup, Architectural changes, Migrations
  * n/a
  
* Library changes
  * all brand simplification updates should bump the major version number

* Side effects
  * changes mixin name used for home header and changes the styles in that mixin

**Screenshots**
* Before (right) After (left)

![image](https://cloud.githubusercontent.com/assets/2359538/23541091/c0838378-ffaa-11e6-932a-5a77d8ce6dd1.png)

**QA Links:**
[http://web.employer-1.development.c66.me/](http://web.employer-1.development.c66.me/)

**How to Verify These Changes**
* Specific pages to visit:
  * Home page - http://web.employer-1.development.c66.me/

* Steps to take
  * squish the page to view the stats bar at different breakpoints
  * Test fancy scroll
    * At full width when scrolling down page, page should scroll over header and header text should fade
    * At breakpoint below which mobile nav appears, none of that should happen

![modern-home](https://cloud.githubusercontent.com/assets/2359538/23541182/635913ba-ffab-11e6-83af-389626f9e394.gif)

* Responsive considerations
  * No fancy scrolling on mobile

**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/692

**Additional Information**