### PR TITLE
EM-854: reduce number of product category boxes on homepage

### DIFF
--- a/sass/_buttons.scss
+++ b/sass/_buttons.scss
@@ -22,6 +22,10 @@ input[type="submit"] {
   @extend %tertiary-button;
 }
 
+.button.bs__button--tertiary {
+  @extend %bs__tertiary-button;
+}
+
 .button.button--tertiary-inverse {
   @extend %tertiary-inverse-button;
 }

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -14,6 +14,19 @@
   left: 0;
 }
 
+// The small strip changes for brand simplification
+@mixin bs__small-strip {
+  content: '';
+  height: $small-strip-height;
+  border-top-right-radius: $minor-border-radius;
+  border-top-left-radius: $minor-border-radius;
+  background-color: $olive-green;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+}
+
 @mixin column-flag {
   color: $white;
   text-align: center;

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -20,7 +20,7 @@
   height: $small-strip-height;
   border-top-right-radius: $minor-border-radius;
   border-top-left-radius: $minor-border-radius;
-  background-color: $olive-green;
+  background-color: $bs__olive-green;
   position: absolute;
   top: 0;
   right: 0;

--- a/sass/directives/_button.scss
+++ b/sass/directives/_button.scss
@@ -109,6 +109,28 @@
   }
 }
 
+%bs__tertiary-button {
+  background-color: $tertiary-button-color;
+  color: $bs__sky-blue;
+  border-color: $bs__sky-blue;
+
+  &:hover {
+    background-color: $bs__sky-blue;
+    color: $tertiary-hover-button-text-color;
+    border-color: $bs__sky-blue;
+  }
+
+  &:active {
+    background-color: $bs__sky-blue;
+    color: $tertiary-active-button-text-color;
+    border-color: $bs__sky-blue;
+  }
+
+  &:disabled, &[disabled]:hover, &[disabled]:active, &.disabled, &.disabled:hover, &.disabled:active {
+    @extend %disabled;
+  }
+}
+
 %tertiary-inverse-button {
   background-color: $tertiary-inverse-button-color;
   color: $tertiary-inverse-button-text-color;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -199,3 +199,6 @@ $table-column-heading-3: $azure-three;
 
 $ecom-table-heading: $table-column-heading-2;
 $ecom-table-promo-heading: darken($table-column-heading-2, 10);
+
+// Brand Simplification Colors
+$olive-green: #66a52a;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -201,4 +201,5 @@ $ecom-table-heading: $table-column-heading-2;
 $ecom-table-promo-heading: darken($table-column-heading-2, 10);
 
 // Brand Simplification Colors
-$olive-green: #66a52a;
+$bs__olive-green: #66a52a;
+$bs__sky-blue: #0097d1;


### PR DESCRIPTION
Adds a few new variables and duplicates / modifies some mixins for the brand simplification toggle on 3/30

Notable Changes:
* Add `bs__small-strip` mixin for toggle
* Add two new colors
* Add alternate `bs__tertiary-button` for the new button styles, per @susan 