### PR TITLE
Style: Placeholders Not Italic

### DIFF
--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -147,7 +147,7 @@ select,
 
   @include placeholder {
     color: $form-placeholder-color;
-    font-style: italic;
+    font-style: normal;
   }
 }
 


### PR DESCRIPTION
**Purpose:**
* Per Susan, placeholders should no longer be italic

**JIRA:**
stems from but is independent of https://cb-content-enablement.atlassian.net/browse/EM-939

**Changes:**
* Changes to setup, Architectural changes, Migrations
  * n/a
  
* Library changes
  * bump patch version number

* Side effects
  * n/a

**Screenshots**
![image](https://cloud.githubusercontent.com/assets/2359538/23672540/ab3f2304-0334-11e7-9830-ad235721b053.png)


**QA Links:**
n/a

**How to Verify These Changes**
* Specific pages to visit:
  * Any page

* Steps to take
  * point your local Employer branch to this style base branch and view the email subscription form at the bottom of every page and/or the buy boxes on the Jobs (/recruiting-solutions/job-postings) page

* Responsive considerations
n/a

**Relevant PRs/Dependencies:**
n/a

**Additional Information**