### PR TITLE
EM-1116: back to top on mobile

### DIFF
--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -96,5 +96,16 @@
 
   @media only screen and (max-width: $small-screen-max) {
     bottom: 3em;
+
+    i {
+      &:hover {
+        background: $grey-darkest;
+        opacity: 0.6;
+
+        i {
+          top: 10%;
+        }
+      }
+    }
   }
 }

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -67,7 +67,7 @@
   -ms-transition: all 0.3s ease;
   -o-transition: all 0.3s ease;
   transition: all 0.3s ease;
-  z-index: 99999999999999;
+  z-index: $tooltip-z-index;
 
   i {
     color: $white;

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -95,6 +95,6 @@
   }
 
   @media only screen and (max-width: $small-screen-max) {
-    display: none;
+    bottom: 3em;
   }
 }


### PR DESCRIPTION
Increases the bottom positioning of the back to top button on mobile so that pressing it no longer opens the Safari iOS navigation menu. Got the idea for the approach from: https://www.eventbrite.com/engineering/mobile-safari-why/

QA Link (view on mobile): http://web.employer-2.development.c66.me/