### PR TITLE
EM-1190: Double Nav

### DIFF
--- a/sass/_buttons.scss
+++ b/sass/_buttons.scss
@@ -6,6 +6,7 @@ input[type="submit"] {
   @extend %button;
 }
 
+// TODO shouldn't need 2-classes, adds specificity
 .button.button--primary {
   @extend %primary-button;
 }

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -51,4 +51,20 @@
     }
   }
 
+  > a:after {
+    font-family: FontAwesome;
+    font-size: $top-bar-icon-size;
+    margin-left: $base-spacing-smallest;
+    color: $base-link-color;
+    content: '\f078';
+    transition: $element-spin-base-transition;
+  }
+
+  &:hover,
+  &.hover {
+    > a:after {
+      transform: $element-spin-rotation-half;
+      color: $header-text-hover-color;
+    }
+  }
 }

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -2,7 +2,7 @@
   position: relative;
 
   ul {
-    @include speech_bubble($pointer-offset: $nav-pointer-offset);
+    @include component-box;
     @include transition($base-transition);
     position: absolute;
     top: $top;

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -23,6 +23,7 @@
       border: 0;
       border-radius: 0;
       padding: 0;
+      box-shadow: none;
     }
 
     // &:after, &:before { // TODO this removed the arrows, nothing should break

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -38,7 +38,7 @@
 
   ul li a {
     color: $base-link-color;
-    font-weight: $font-weight-normal;
+    font-weight: $font-weight-bold;
 
     &.top-bar__link:hover,
     &:hover .top-bar__link {

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -46,6 +46,7 @@
 
   ul li a {
     color: $base-link-color;
+    font-size: $top-bar-font-size;
     font-weight: $font-weight-bold;
 
     &:hover,

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -23,11 +23,11 @@
       padding: 0;
     }
 
-    &:after, &:before {
-      @media only screen and (max-width: $mobile-nav-max) {
-        content: none;
-      }
-    }
+    // &:after, &:before { // TODO this removed the arrows, nothing should break
+    //   @media only screen and (max-width: $mobile-nav-max) {
+    //     content: none;
+    //   }
+    // }
   }
 
   // Hover and Click behavior above hamburger menu range

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -61,8 +61,9 @@
     }
 
     @media only screen and (max-width: $mobile-nav-max) {
+      padding: 10px 24px; // TODO when we update mobile nav update these numbers; currently sizes shouldn't change, so don't want to use the spacing variables that will change before mobile nav
       color: $base-link-color;
-      // text-indent: $type-indent;
+      text-indent: $type-indent;
     }
   }
 

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -61,7 +61,7 @@
 
     @media only screen and (max-width: $mobile-nav-max) {
       color: $base-link-color;
-      text-indent: 2em;
+      // text-indent: $type-indent;
     }
   }
 

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -11,7 +11,7 @@
     z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
     width: auto;
     height: auto;
-    padding: 25px;
+    padding: 0;
     display: none;
 
     @media only screen and (max-width: $mobile-nav-max) {
@@ -40,11 +40,12 @@
   }
 
   ul li {
-    padding: 7px 10px;
-    display: block;
+    list-style-type: none;
   }
 
   ul li a {
+    display: block;
+    padding: $base-spacing-small $base-spacing-medium;
     color: $base-link-color;
     font-size: $top-bar-font-size;
     font-weight: $font-weight-bold;

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -11,6 +11,8 @@
     z-index: z($z-context, navigation, $navigation, top-bar--primary__flyout__ul);
     width: auto;
     height: auto;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
     padding: 0;
     display: none;
 

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -65,10 +65,10 @@
 
   > a:after {
     font-family: FontAwesome;
-    font-size: $top-bar-icon-size;
+    font-size: $top-bar-angle-size;
     margin-left: $base-spacing-smallest;
     color: $base-link-color;
-    content: '\f078';
+    content: '\f107';
     transition: $element-spin-base-transition;
   }
 

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -25,12 +25,6 @@
       padding: 0;
       box-shadow: none;
     }
-
-    // &:after, &:before { // TODO this removed the arrows, nothing should break
-    //   @media only screen and (max-width: $mobile-nav-max) {
-    //     content: none;
-    //   }
-    // }
   }
 
   // Hover and Click behavior above hamburger menu range

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -1,4 +1,4 @@
-@mixin nav_flyout($top, $flyout-offset-value, $flyout-offset-direction: 'left', $nav-pointer-offset: 25%) {
+@mixin nav_flyout($top, $flyout-offset-value, $flyout-offset-direction: 'left') { // TODO may not need any params
   position: relative;
 
   ul {

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -48,9 +48,11 @@
     color: $base-link-color;
     font-weight: $font-weight-bold;
 
-    &.top-bar__link:hover,
-    &:hover .top-bar__link {
-      text-decoration: underline;
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: none;
+      background-color: $grey-mid-lightest;
     }
 
     @media only screen and (max-width: $mobile-nav-max) {

--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -14,7 +14,6 @@
     padding: 25px;
     display: none;
 
-
     @media only screen and (max-width: $mobile-nav-max) {
       position: relative;
       top: 0;
@@ -28,6 +27,15 @@
       @media only screen and (max-width: $mobile-nav-max) {
         content: none;
       }
+    }
+  }
+
+  // Hover and Click behavior above hamburger menu range
+
+  &:hover ul,
+  &.hover ul {
+    @media only screen and (min-width: $mobile-nav-max) {
+      display: block;
     }
   }
 

--- a/sass/variables/_animations.scss
+++ b/sass/variables/_animations.scss
@@ -12,4 +12,6 @@ $element-spin-base-transition: all 300ms 0s ease-in-out;
 
 $element-spin-rotation-full: rotate(360deg);
 
+$element-spin-rotation-half: rotate(540deg);
+
 $element-slow-fade-in: 0.4s;

--- a/sass/variables/_breakpoints.scss
+++ b/sass/variables/_breakpoints.scss
@@ -7,5 +7,5 @@ $medium-screen-max: 64em; // (1024px)
 $large-screen-min: $medium-screen-max;
 
 // Nav breakpoints
-$midrange-nav-max: 88.5em; // (1408px) Point at which full nav no longer fits in one line
-$mobile-nav-max: 66.5em; // (1064px) Point at which full nav + collapsed right-side nav no longer fit in one line
+$midrange-nav-max: 56em; // (~880px) Point at which full nav no longer fits in one line
+$mobile-nav-max: 31em; // (490px) Point at which full nav + collapsed right-side nav no longer fit in one line

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -97,6 +97,7 @@ $alert-warning: $marigold;
 $alert-success: $lime;
 
 // Header/Footer
+$header-background-color--account-bar: $anchor-blue;
 $header-mobile-icon-color: $anchor-blue;
 $header-mobile-text-hover-color: $white;
 $header-text-color: $anchor-blue;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -47,6 +47,7 @@ $grey: #CCCCCC;
 $grey-semi-light: #D4D4D4; // border color
 $grey-light: #DDDDDD;
 $grey-lighter: #EEEEEE;
+$grey-mid-lightest: #E4E4E4;
 $grey-lightest: #F4F4F4;
 
 // Brand Simplification - new colors; temporary names

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -100,6 +100,7 @@ $alert-success: $lime;
 // Header/Footer
 $header-background-color--account-nav: $anchor-blue;
 $header-background-color--site-nav: $white;
+$header-background-color--mobile-nav: $white;
 $header-background-color: $white; // mobile?
 $header-mobile-icon-color: $anchor-blue;
 $header-mobile-text-hover-color: $white;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -97,11 +97,13 @@ $alert-warning: $marigold;
 $alert-success: $lime;
 
 // Header/Footer
-$header-background-color--account-bar: $anchor-blue;
+$header-background-color--account-nav: $anchor-blue;
+$header-background-color--site-nav: $white;
+$header-background-color: $white; // mobile?
 $header-mobile-icon-color: $anchor-blue;
 $header-mobile-text-hover-color: $white;
 $header-text-color: $anchor-blue;
-$header-background-color: $white;
+$header-text-hover-color: $white;
 $header-background-secondary-color: $grey-lighter;
 $header-flyout-color: $header-background-color;
 $header-subtitle-color: $grey-darker;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -127,7 +127,7 @@ $massive-button-horizontal-padding: $base-input-font-size * 2;
 // Top Bar
 $top-bar--height: 56px;
 $top-bar--height-combined: 56px * 2;
-$top-bar--height--mobile: $top-bar--height-combined; // TODO making this 56 for easy math but need to talk to susan about whether it should stay the small height then figure out the rest
+$top-bar--height--mobile: 42px;
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 20px;
 $top-bar-font-size: $small-font-size;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -125,11 +125,12 @@ $massive-button-vertical-padding: $base-input-font-size * 0.375;
 $massive-button-horizontal-padding: $base-input-font-size * 2;
 
 // Top Bar
-$top-bar--height: 60px;
+$top-bar--height: 56px;
 $top-bar--height--mobile: 42px;
 $top-bar--logo-width: 192px;
-$top-bar--logo-height: 32px;
+$top-bar--logo-height: 20px;
 $top-bar-font-size: $small-font-size;
+$top-bar-icon-size: 0.75rem;
 
 // Header
 $header-height-large: 445px;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -127,7 +127,7 @@ $massive-button-horizontal-padding: $base-input-font-size * 2;
 // Top Bar
 $top-bar--height: 56px;
 $top-bar--height-combined: 56px * 2;
-$top-bar--height--mobile: 42px;
+$top-bar--height--mobile: $top-bar--height-combined; // TODO making this 56 for easy math but need to talk to susan about whether it should stay the small height then figure out the rest
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 20px;
 $top-bar-font-size: $small-font-size;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -131,7 +131,8 @@ $top-bar--height--mobile: $top-bar--height-combined; // TODO making this 56 for 
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 20px;
 $top-bar-font-size: $small-font-size;
-$top-bar-icon-size: 0.75rem;
+$top-bar-icon-size: 0.75rem; // 12px
+$top-bar-angle-size: 1rem; // 16px
 
 // Header
 $header-height-large: 445px;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -126,6 +126,7 @@ $massive-button-horizontal-padding: $base-input-font-size * 2;
 
 // Top Bar
 $top-bar--height: 56px;
+$top-bar--height-combined: 56px * 2;
 $top-bar--height--mobile: 42px;
 $top-bar--logo-width: 192px;
 $top-bar--logo-height: 20px;


### PR DESCRIPTION
**Purpose:**

> As a user, I want to have a cleaner site experience so that my navigation is simpler and easier to use across the employer and resource sites.

* Several style updates to create new 2-part nav bar
    * Updates to flyouts

Before:
![image](https://cloud.githubusercontent.com/assets/2359538/25393389/f37dc2a0-29a0-11e7-86bd-52d6acaf9d0d.png)

After: 
![image](https://cloud.githubusercontent.com/assets/2359538/25393404/fbfa4e08-29a0-11e7-82b6-82634bfa1b97.png)

* Breakpoints are much lower so everyone can see the full nav on a 13" screen

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1190

**Changes:**
* Changes to setup, Architectural changes, Migrations, Library changes, Side effects
  * n/a

**Screenshots**

See https://github.com/cbdr/employer/pull/794


**QA Links:**
Signed In: http://web.employer-7.development.c66.me/
Signed Out: http://a01c3356.ngrok.io/

**How to Verify These Changes**
* Specific pages to visit
  * any

* Steps to take
  * Behold the double nav

* Responsive considerations
  * Mobile nav should appear unchanged
  * Breakpoints for mid-range and mobile nav are much lower


**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/794

**Additional Information**
