### PR TITLE
EM-1190: Maintain Rounded Corners on Flyouts

### DIFF
--- a/sass/directives/_flyout.scss
+++ b/sass/directives/_flyout.scss
@@ -61,6 +61,15 @@
     }
   }
 
+  ul li:last-of-type a {
+    &:hover,
+    &:active,
+    &:focus {
+      border-bottom-left-radius: $minor-border-radius;
+      border-bottom-right-radius: $minor-border-radius;
+    }
+  }
+
   > a:after {
     font-family: FontAwesome;
     font-size: $top-bar-angle-size;


### PR DESCRIPTION
**Purpose:**
- Maintains rounded corners when last `a` tag in a `.flyout` is in `hover` `active` or `focus` state

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1190

**Changes:**
* Changes to setup, Architectural changes, Migrations, Library changes, Side effects
  * n/a

**Screenshots**

Before:

![image](https://cloud.githubusercontent.com/assets/2359538/25449271/e2da007c-2a80-11e7-8652-fb37107ba5a7.png)

After:

![image](https://cloud.githubusercontent.com/assets/2359538/25449224/c12e68c8-2a80-11e7-907c-52cd10b7f33d.png)


**QA Links:**
http://a01c3356.ngrok.io/

**How to Verify These Changes**
* Specific pages to visit
  * any

* Steps to take
  * Hover over Browse Products
  * Hover over the last item in Browse Products
  * See that the bottom left and right corners of the flyout are still rounded

* Responsive considerations
n/a

**Relevant PRs/Dependencies:**
https://github.com/cb-talent-development/employer-style-base/pull/84
https://github.com/cbdr/employer/pull/794

**Additional Information**
