### PR TITLE
EM-1319: Authority Stat Section

### DIFF
--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -14,6 +14,14 @@
   left: 0;
 }
 
+@mixin divider_line($divider-line-size: 3em) {
+  max-width: $divider-line-size;
+  border-bottom: 2px solid white;
+  margin: auto;
+  margin-top: $type-margin;
+  margin-bottom: $type-margin;
+}
+
 // The small strip changes for brand simplification
 @mixin bs__small-strip {
   content: '';

--- a/sass/directives/_gradients.scss
+++ b/sass/directives/_gradients.scss
@@ -106,6 +106,14 @@ $gradient_var_list: (
   background-attachment: fixed;
 }
 
+@mixin imageGradient($img-url, $dark, $medium, $light) {
+  background-color: $light;
+  background-image:
+    linear-gradient(to right, rgba($dark, 0.8), rgba($medium, 0.75), rgba($light, 0.2)),
+    url($img-url);
+  background-attachment: fixed;
+}
+
 
 // ## Gradient Implementation ##
 


### PR DESCRIPTION
Adds the Divider Line mixin for use with the new Authority Stats section.

Relevant Employer PR: https://github.com/cbdr/employer/pull/839

Example:
<img width="1280" alt="screen shot 2017-05-15 at 11 33 25 am" src="https://cloud.githubusercontent.com/assets/8419757/26068361/d7e948d0-3962-11e7-880e-5445c7432182.png">

Requested Mockup:
![authority stat](https://cloud.githubusercontent.com/assets/8419757/26068382/ece488e4-3962-11e7-9ec2-936559b83efd.jpg)