### PR TITLE
EM-1399: Make email capture field and button same height

### DIFF
--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -83,7 +83,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color
 // Input Sizes
 $form-input-font-size: $base-font-size;
 $base-input-font-size: $form-input-font-size;
-$form-input-vertical-padding: $form-input-font-size * 0.6;
+$form-input-vertical-padding: $form-input-font-size * 0.4;
 $form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;


### PR DESCRIPTION
A very simple tweak, changes the vertical padding for form inputs to make it the same size as the button size - reducing it `0.2em` from `0.6` to `0.4`