### PR TITLE
EM-1317: Small Biz Visual Overview Section Mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "1.1.9",
+  "version": "2.1.1",
   "authors": [
     "Content Enablement <ContentEnablementProductTeam@careerbuilder.com>"
   ],

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -28,6 +28,7 @@
 @import "directives/tables";
 @import "directives/tooltips";
 @import "directives/visibility";
+@import "directives/visual-guides";
 @import "directives/z_index";
 
 @import "buttons";

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -22,6 +22,33 @@
   margin-bottom: $type-margin;
 }
 
+// A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
+// The guide extends out of its relatively positioned parent container on the bottom and top
+// This guide does not include steps. It is only a center line.
+// You must have a parent container (relatively positioned) for this to work properly.
+@mixin column-guide {
+  bottom: -200px;
+  left: 0;
+  margin: auto;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: -65px;
+  width: 50px;
+
+  &:before, &:after {
+    content: '';
+    background-color: white;
+    border: $base-border;
+    border-radius: 7px; //TODO: New variable?
+    display: block;
+    height: 14px;
+    margin: 0 auto;
+    position: relative;
+    width: 14px;
+  }
+}
+
 // The small strip changes for brand simplification
 @mixin bs__small-strip {
   content: '';

--- a/sass/directives/_accents.scss
+++ b/sass/directives/_accents.scss
@@ -22,33 +22,6 @@
   margin-bottom: $type-margin;
 }
 
-// A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
-// The guide extends out of its relatively positioned parent container on the bottom and top
-// This guide does not include steps. It is only a center line.
-// You must have a parent container (relatively positioned) for this to work properly.
-@mixin column-guide {
-  bottom: -200px;
-  left: 0;
-  margin: auto;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  top: -65px;
-  width: 50px;
-
-  &:before, &:after {
-    content: '';
-    background-color: white;
-    border: $base-border;
-    border-radius: 7px; //TODO: New variable?
-    display: block;
-    height: 14px;
-    margin: 0 auto;
-    position: relative;
-    width: 14px;
-  }
-}
-
 // The small strip changes for brand simplification
 @mixin bs__small-strip {
   content: '';

--- a/sass/directives/_headings.scss
+++ b/sass/directives/_headings.scss
@@ -27,6 +27,18 @@
   }
 }
 
+@mixin heading--hero--sm {
+  h1 {
+    font-size: $h1-font-size;
+    font-weight: $font-weight-light;
+  }
+
+  p {
+    color: $paragraph-text-color;
+    font-size: $body-font-size;
+  }
+}
+
 @mixin heading--section {
   margin-bottom: 20px;
 

--- a/sass/directives/_headings.scss
+++ b/sass/directives/_headings.scss
@@ -27,15 +27,14 @@
   }
 }
 
-@mixin heading--hero--sm {
+@mixin heading--section--sm {
   h1 {
-    font-size: $h1-font-size;
+    font-size: 1.875rem;
     font-weight: $font-weight-light;
   }
 
   p {
     color: $paragraph-text-color;
-    font-size: $body-font-size;
   }
 }
 

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -1,3 +1,11 @@
+/* Preliminary mixin for flexbox. TODO: Move to an appropriate file. */
+@mixin display-modified-flex {
+  display: -webkit-box;
+  display: -moz-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 /* A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
  * The guide can extend out of its relatively positioned parent container on the bottom and top
  * This guide does not include steps. It is only a center line.
@@ -49,11 +57,11 @@
  * TODO: Concerning guides with no steps
  */
 @mixin visual-guide-row ($counter) {
-  @include display(flex);
+  @include display-modified-flex;
   position: relative;
 
   .visual-guide__content, .visual-guide__image {
-    @include display(flex);
+    @include display-modified-flex;
     width: 50%;
 
     &:first-of-type {
@@ -105,7 +113,7 @@
     border-radius: 50%;
     bottom: 0;
     box-sizing: border-box;
-    @include display(flex);
+    @include display-modified-flex;
     font-size: $body-font-size;
     font-weight: $font-weight-bold;
     height: $visual-guide-step-size;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -1,11 +1,3 @@
-/* Preliminary mixin for flexbox. TODO: Move to an appropriate file. */
-@mixin display-modified-flex {
-  display: -webkit-box;
-  display: -moz-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 /* A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
  * The guide can extend out of its relatively positioned parent container on the bottom and top
  * This guide does not include steps. It is only a center line.
@@ -57,11 +49,11 @@
  * TODO: Concerning guides with no steps
  */
 @mixin visual-guide-row ($counter) {
-  @include display-modified-flex;
+  @include display(flex);
   position: relative;
 
   .visual-guide__content, .visual-guide__image {
-    @include display-modified-flex;
+    @include display(flex);
     width: 50%;
 
     &:first-of-type {
@@ -113,7 +105,7 @@
     border-radius: 50%;
     bottom: 0;
     box-sizing: border-box;
-    @include display-modified-flex;
+    @include display(flex);
     font-size: $body-font-size;
     font-weight: $font-weight-bold;
     height: $visual-guide-step-size;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -79,7 +79,6 @@
     snippet {
       align-self: center;
       width: 90%;
-      max-width: 460px;
     }
 
     &.guide__image--left {

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -75,8 +75,14 @@
   }
 
   .visual__guide__image {
+    align-self: center;
+
     &.guide__image--left {
       justify-content: flex-end;
+    }
+
+    img {
+      height: 100%;
     }
   }
 
@@ -112,7 +118,7 @@
     width: 42px;
 
     span:after {
-      content: counter($counter);
+      content: counter(overview-count);
     }
   }
 }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -68,17 +68,13 @@
   .visual-guide__content {
     &.guide__content--left {
       @include justify-content(flex-end);
-      padding-left: $container-edge-padding;
     }
   }
 
   .visual-guide__image {
     @include align-self(center);
-
-    &.guide__image--left {
-      @include justify-content(flex-end);
-    }
-
+    @include justify-content(center);
+    
     img {
       height: 100%;
     }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -14,17 +14,15 @@
   }
 
   left: 0;
-  margin: auto;
   position: absolute;
   right: 0;
-  text-align: center;
-  width: 50px;
 
   &:before, &:after {
     content: '';
     background-color: white;
     border: $base-border;
     border-radius: 50%;
+    box-sizing: border-box;
     display: block;
     height: $visual-divider-endpoint-size;
     margin: 0 auto;
@@ -70,7 +68,7 @@
   .visual-guide__content {
     &.guide__content--left {
       justify-content: flex-end;
-      padding-left: $type-margin;
+      padding-left: $container-edge-padding;
     }
   }
 
@@ -89,12 +87,8 @@
   .visual-guide__item-description {
     align-self: center;
 
-    .small-biz__overview__block--step {
-      font-weight: bold;
-    }
-
     h3 {
-      font-size: 2em;
+      font-size: 1.875rem;
       font-weight: $font-weight-light;
     }
 
@@ -110,8 +104,10 @@
     border: $visual-guide-step-border;
     border-radius: 50%;
     bottom: 0;
+    box-sizing: border-box;
     display: flex;
     font-size: $body-font-size;
+    font-weight: $font-weight-bold;
     height: $visual-guide-step-size;
     justify-content: center;
     left: 0;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -75,12 +75,6 @@
   }
 
   .visual__guide__image {
-    //TODO: Add non-IPE
-    snippet {
-      align-self: center;
-      width: 90%;
-    }
-
     &.guide__image--left {
       justify-content: flex-end;
     }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -111,6 +111,7 @@
     border-radius: 50%;
     bottom: 0;
     display: flex;
+    font-size: $body-font-size;
     height: $visual-guide-step-size;
     justify-content: center;
     left: 0;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -72,7 +72,7 @@
     snippet {
       align-self: center;
       width: 90%;
-      max-width: 600px;
+      max-width: 460px;
     }
 
     &.guide__image--left {

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -4,7 +4,7 @@
  * You must have a parent container (relatively positioned) for this to work properly.
  */
 @mixin visual-guide-divider {
-  bottom: -200px;
+  bottom: -65px;
   left: 0;
   margin: auto;
   position: absolute;
@@ -27,7 +27,7 @@
 
   .visual__guide__divider {
     background-color: $base-border-primary-color;
-    height: 93%;
+    height: 100%;
     margin: 0 auto;
     width: 1px;
   }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -24,19 +24,19 @@
     content: '';
     background-color: white;
     border: $base-border;
-    border-radius: 7px; //TODO: New border radius variable?
+    border-radius: 50%;
     display: block;
-    height: 14px;
+    height: 14px; //Variable
     margin: 0 auto;
     position: relative;
-    width: 14px;
+    width: 14px;  //Variable
   }
 
   &:after {
     background-color: $grey-lighter;
   }
 
-  .visual__guide__divider {
+  .visual-guide__divider {
     background-color: $base-border-primary-color;
     height: 100%;
     margin: 0 auto;
@@ -54,7 +54,7 @@
   display: flex;
   position: relative;
 
-  .visual__guide__content, .visual__guide__image {
+  .visual-guide__content, .visual-guide__image {
     display: flex;
     width: 50%;
 
@@ -67,14 +67,14 @@
     }
   }
 
-  .visual__guide__content {
+  .visual-guide__content {
     &.guide__content--left {
       justify-content: flex-end;
       padding-left: $type-margin;
     }
   }
 
-  .visual__guide__image {
+  .visual-guide__image {
     align-self: center;
 
     &.guide__image--left {
@@ -86,39 +86,42 @@
     }
   }
 
-  .visual__guide__item__description {
+  .visual-guide__item-description {
     align-self: center;
-    max-width: 509px;
 
-    h4 {
-      font-size: $h1-font-size;
+    .small-biz__overview__block--step {
+      font-weight: bold;
+    }
+
+    h3 {
+      font-size: 2em;
       font-weight: $font-weight-light;
     }
 
     p {
       color: $paragraph-text-color;
-      font-size: $body-font-size;
     }
   }
 
   // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
-  span.visual__guide__step {
+  span.visual-guide__step {
+    align-items: center;
     background-color: white;
-    border: 2px solid $azure-blue; //TODO: New border variable?
-    border-radius: 23px;
+    border: 2px solid $azure-blue; // Variable
+    border-radius: 50%;
     bottom: 0;
-    height: 42px;
+    display: flex;
+    height: 42px; //Variable
+    justify-content: center;
     left: 0;
-    line-height: 35px;
     margin: auto;
     position: absolute;
     right: 0;
-    text-align: center;
     top: 0;
-    width: 42px;
+    width: 42px; //Variable
 
     span:after {
-      content: counter(overview-count);
+      content: counter($counter);
     }
   }
 }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -4,13 +4,20 @@
  * You must have a parent container (relatively positioned) for this to work properly.
  */
 @mixin visual-guide-divider($extend-top: 0px, $extend-bottom: 0px) {
-  bottom: $extend-top;
+
+  @if $extend-top != 0px {
+    bottom: -($extend-bottom);
+    top: -($extend-top);
+  } @else {
+    bottom: $extend-bottom;
+    top: $extend-top;
+  }
+
   left: 0;
   margin: auto;
   position: absolute;
   right: 0;
   text-align: center;
-  top: $extend-bottom;
   width: 50px;
 
   &:before, &:after {

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -25,6 +25,10 @@
     width: 14px;
   }
 
+  &:after {
+    background-color: $grey-lighter;
+  }
+
   .visual__guide__divider {
     background-color: $base-border-primary-color;
     height: 100%;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -1,0 +1,114 @@
+/* A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
+ * The guide extends out of its relatively positioned parent container on the bottom and top
+ * This guide does not include steps. It is only a center line.
+ * You must have a parent container (relatively positioned) for this to work properly.
+ */
+@mixin visual-guide-divider {
+  bottom: -200px;
+  left: 0;
+  margin: auto;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: -65px;
+  width: 50px;
+
+  &:before, &:after {
+    content: '';
+    background-color: white;
+    border: $base-border;
+    border-radius: 7px; //TODO: New variable?
+    display: block;
+    height: 14px;
+    margin: 0 auto;
+    position: relative;
+    width: 14px;
+  }
+
+  .visual__guide__divider {
+    background-color: $base-border-primary-color;
+    height: 93%;
+    margin: 0 auto;
+    width: 1px;
+  }
+}
+
+/* For <li> elements only within a <ol>
+ * Parameter takes in a CSS counter that must be set / reset elsewhere
+ * Each row (your <li> content) consists of a block of text, and an image, with a center gutter.
+ * Modifiers include left properties to right justify content blocks (not text) along the center gutter.
+ * TODO: Concerning guides with no steps
+ */
+@mixin visual-guide-row ($counter) {
+  display: flex;
+  position: relative;
+
+  .visual__guide__content, .visual__guide__image {
+    display: flex;
+    width: 50%;
+
+    &:first-of-type {
+      margin-right: $base-spacing-large;
+    }
+
+    &:last-of-type {
+      margin-left: $base-spacing-large;
+    }
+  }
+
+  .visual__guide__content {
+    &.guide__content--left {
+      justify-content: flex-end;
+      padding-left: $type-margin;
+    }
+  }
+
+  .visual__guide__image {
+    //TODO: Add non-IPE
+    snippet {
+      align-self: center;
+      width: 90%;
+      max-width: 600px;
+    }
+
+    &.guide__image--left {
+      justify-content: flex-end;
+    }
+  }
+
+  .visual__guide__item__description {
+    align-self: center;
+    max-width: 509px;
+
+    h4 {
+      font-size: $h1-font-size;
+      font-weight: $font-weight-light;
+    }
+
+    p {
+      color: $paragraph-text-color;
+      font-size: $body-font-size;
+    }
+  }
+
+  // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
+  span.visual__guide__step {
+    background-color: white;
+    border: 2px solid $azure-blue; //TODO: New border variable
+    border-radius: 23px;
+    bottom: 0;
+    height: 42px;
+    left: 0;
+    line-height: 35px;
+    margin: auto;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    top: 0;
+    width: 42px;
+
+    span:after {
+      content: counter($counter);
+    }
+  }
+}

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -26,10 +26,10 @@
     border: $base-border;
     border-radius: 50%;
     display: block;
-    height: 14px; //Variable
+    height: $visual-divider-endpoint-size;
     margin: 0 auto;
     position: relative;
-    width: 14px;  //Variable
+    width: $visual-divider-endpoint-size;
   }
 
   &:after {
@@ -107,18 +107,18 @@
   span.visual-guide__step {
     align-items: center;
     background-color: white;
-    border: 2px solid $azure-blue; // Variable
+    border: $visual-guide-step-border;
     border-radius: 50%;
     bottom: 0;
     display: flex;
-    height: 42px; //Variable
+    height: $visual-guide-step-size;
     justify-content: center;
     left: 0;
     margin: auto;
     position: absolute;
     right: 0;
     top: 0;
-    width: 42px; //Variable
+    width: $visual-guide-step-size;
 
     span:after {
       content: counter($counter);

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -49,11 +49,11 @@
  * TODO: Concerning guides with no steps
  */
 @mixin visual-guide-row ($counter) {
-  display: flex;
+  @include display(flex);
   position: relative;
 
   .visual-guide__content, .visual-guide__image {
-    display: flex;
+    @include display(flex);
     width: 50%;
 
     &:first-of-type {
@@ -67,16 +67,16 @@
 
   .visual-guide__content {
     &.guide__content--left {
-      justify-content: flex-end;
+      @include justify-content(flex-end);
       padding-left: $container-edge-padding;
     }
   }
 
   .visual-guide__image {
-    align-self: center;
+    @include align-self(center);
 
     &.guide__image--left {
-      justify-content: flex-end;
+      @include justify-content(flex-end);
     }
 
     img {
@@ -85,7 +85,7 @@
   }
 
   .visual-guide__item-description {
-    align-self: center;
+    @include align-self(center);
 
     h3 {
       font-size: 1.875rem;
@@ -99,17 +99,17 @@
 
   // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
   span.visual-guide__step {
-    align-items: center;
+    @include align-items(center);
     background-color: white;
     border: $visual-guide-step-border;
     border-radius: 50%;
     bottom: 0;
     box-sizing: border-box;
-    display: flex;
+    @include display(flex);
     font-size: $body-font-size;
     font-weight: $font-weight-bold;
     height: $visual-guide-step-size;
-    justify-content: center;
+    @include justify-content(center);
     left: 0;
     margin: auto;
     position: absolute;

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -1,23 +1,23 @@
 /* A simple, center dividing column guide / line. See /recruiting-solutions/small-business-subscription-plans-and-pricing
- * The guide extends out of its relatively positioned parent container on the bottom and top
+ * The guide can extend out of its relatively positioned parent container on the bottom and top
  * This guide does not include steps. It is only a center line.
  * You must have a parent container (relatively positioned) for this to work properly.
  */
-@mixin visual-guide-divider {
-  bottom: -65px;
+@mixin visual-guide-divider($extend-top: 0px, $extend-bottom: 0px) {
+  bottom: $extend-top;
   left: 0;
   margin: auto;
   position: absolute;
   right: 0;
   text-align: center;
-  top: -65px;
+  top: $extend-bottom;
   width: 50px;
 
   &:before, &:after {
     content: '';
     background-color: white;
     border: $base-border;
-    border-radius: 7px; //TODO: New variable?
+    border-radius: 7px; //TODO: New border radius variable?
     display: block;
     height: 14px;
     margin: 0 auto;
@@ -94,7 +94,7 @@
   // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
   span.visual__guide__step {
     background-color: white;
-    border: 2px solid $azure-blue; //TODO: New border variable
+    border: 2px solid $azure-blue; //TODO: New border variable?
     border-radius: 23px;
     bottom: 0;
     height: 42px;

--- a/sass/variables/_colors.scss
+++ b/sass/variables/_colors.scss
@@ -242,3 +242,6 @@ $table-column-heading-3: $sky-blue;
 
 $ecom-table-heading: $table-column-heading-2;
 $ecom-table-promo-heading: darken($table-column-heading-2, 10);
+
+// Visual Guides
+$visual-guide-step-border: 2px solid $azure-blue;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -76,8 +76,8 @@ $accordion-icon-size: 30px;
 $accordion-toggle--round-size: 60px;
 $accordion-angle-size: 35px;
 $resource-continue-block-size: 40px;
-$visual-divider-endpoint-size: 14px;
-$visual-guide-step-size: 42px;
+$visual-divider-endpoint-size: 15px;
+$visual-guide-step-size: 44px;
 $visual-guide-content-width: 509px;
 $visual-guide-image-height: 290px;
 

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -76,10 +76,12 @@ $accordion-icon-size: 30px;
 $accordion-toggle--round-size: 60px;
 $accordion-angle-size: 35px;
 $resource-continue-block-size: 40px;
-$visual-divider-endpoint-size: 15px;
+$visual-divider-endpoint-size: 14px;
 $visual-guide-step-size: 44px;
 $visual-guide-content-width: 509px;
-$visual-guide-image-height: 290px;
+$visual-guide-image-large: 290px;
+$visual-guide-image-medium: 275px;
+$visual-guide-image-small: 170px;
 
 // Forms
 $form-border-radius: $minor-border-radius;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -76,6 +76,10 @@ $accordion-icon-size: 30px;
 $accordion-toggle--round-size: 60px;
 $accordion-angle-size: 35px;
 $resource-continue-block-size: 40px;
+$visual-divider-endpoint-size: 14px;
+$visual-guide-step-size: 42px;
+$visual-guide-content-width: 509px;
+$visual-guide-image-height: 290px;
 
 // Forms
 $form-border-radius: $minor-border-radius;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -64,6 +64,8 @@ $type-margin: 20px;
 $type-margin--small: 12px;
 $type-indent: 2em;
 
+$container-edge-padding: 20px; //Use this if using an unconventional body container and still need the default left /right padding some of our containers have (20px)
+
 // UI components
 $medium-icon-font-size: 25px;
 $direction-arrow-size: 2em;
@@ -76,8 +78,8 @@ $accordion-icon-size: 30px;
 $accordion-toggle--round-size: 60px;
 $accordion-angle-size: 35px;
 $resource-continue-block-size: 40px;
-$visual-divider-endpoint-size: 14px;
-$visual-guide-step-size: 44px;
+$visual-divider-endpoint-size: 13px;
+$visual-guide-step-size: 42px;
 $visual-guide-content-width: 509px;
 $visual-guide-image-large: 290px;
 $visual-guide-image-medium: 275px;
@@ -92,7 +94,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color
 // Input Sizes
 $form-input-font-size: $base-font-size;
 $base-input-font-size: $form-input-font-size;
-$form-input-vertical-padding: $form-input-font-size * 0.4;
+$form-input-vertical-padding: $form-input-font-size * 0.6;
 $form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -86,7 +86,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color
 // Input Sizes
 $form-input-font-size: $base-font-size;
 $base-input-font-size: $form-input-font-size;
-$form-input-vertical-padding: $form-input-font-size * 0.6;
+$form-input-vertical-padding: $form-input-font-size * 0.4;
 $form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;


### PR DESCRIPTION
**Purpose:**
Adds a new stylesheet for visual overview sections like the example shown in the Jira below.
* The addition of _visual-guides.scss
* New mixin: `visual-guide-divider()` which adds styles for a simple center divider used for an overview section.
* New mixin: `visual-guide-row()` which adds boilerplate styles for each row in a visual flow that are laid out using an ordered list.

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1317

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
  * New file: `_visual-guides.scss`

* Migrations
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A
* After
N/A

**QA Links:**
http://web.employer-2.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

**How to Verify These Changes**
* Specific pages to visit
  * Visit the QA link

* Steps to take
  * Go to the Overview section (How to Find the Best Candidates in 4 Simple Steps)
  * Make sure it looks ok, verify measurements with Susan's comps



* Responsive considerations
  * NOTE: This does not include any mobile styles.  This will be addressed in EM-1344! Overall, the page should just shrink with both columns maintaining their width with the images scaling.
  * Open dev tools in responsive mode and resize the window, take note of the following:
      * The images should scale, and always remain vertically center with their associated copy
      * The same holds true with the copy.
      * The same holds true with the step number located in the center gutter. The number should adjust its position as the content resizes.
      * The images should stop scaling around ~1450px. Their height should be around ~290px for desktop screens. Around ~275px at 1050px.


**Relevant PRs/Dependencies:**


**Additional Information**
