### PR TITLE
EM-1399: Adjust Input and Button Heights on .fieldset--large

### DIFF
--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -332,7 +332,7 @@ form button {
 .fieldset--large {
   @include display(flex);
   @include flex-wrap(nowrap);
-  @include align-items(center);
+  @include align-items(stretch);
 
   & #{$all-text-inputs},
   & select,
@@ -359,6 +359,8 @@ form button {
     @media only screen and (min-width: $small-screen-max) {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
+      padding-top: 0;
+      padding-bottom: 0;
     }
 
     @media only screen and (max-width: $small-screen-max) {

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -83,7 +83,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color
 // Input Sizes
 $form-input-font-size: $base-font-size;
 $base-input-font-size: $form-input-font-size;
-$form-input-vertical-padding: $form-input-font-size * 0.4;
+$form-input-vertical-padding: $form-input-font-size * 0.6;
 $form-input-horizontal-padding: $form-input-font-size * 1.25;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;


### PR DESCRIPTION
Alternative fix for https://github.com/cb-talent-development/employer-style-base/pull/92
 - This change appeared to make the input field too narrow and would have affected inputs other than the combined input + button

![image](https://cloud.githubusercontent.com/assets/2359538/26343077/4227e3a2-3f60-11e7-89ec-7831322a95c5.png)

 - Using flexbox instead so that input and button stretch to the same height within the `.fieldset--large` class

![image](https://cloud.githubusercontent.com/assets/2359538/26343260/d60a26f2-3f60-11e7-972c-304b45314f33.png)


**Q/A Link**: http://7cf60a0c.ngrok.io
**Jira**: https://cb-content-enablement.atlassian.net/browse/EM-1399
**Related PR**: https://github.com/cb-talent-development/employer-style-base/pull/92