### PR TITLE
EM-1343: Mobile Compare Chart

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -25,6 +25,7 @@
 @import "directives/media";
 @import "directives/modals";
 @import "directives/speech_bubble";
+@import "directives/tabs";
 @import "directives/tables";
 @import "directives/tooltips";
 @import "directives/visibility";

--- a/sass/directives/_tables.scss
+++ b/sass/directives/_tables.scss
@@ -108,6 +108,29 @@
   }
 }
 
+
+/* table--row-column-headers--mobile: Adds 100vw wrap for mobile, calculates table width based on number of columns, adjusts pixels due to border-collapse: collapse. For use with Tab component. Expects Tab component is adjacent to table and reflects selected tab with class in .selectedTab--0 format
+*/
+@mixin table--row-column-headers--mobile($columns) {
+  $length: $columns - 1;
+
+  width: calc((#{$columns} * 100%) - (#{$length} * 1px));
+  margin-left: -$container-edge-padding;
+  position: relative;
+
+
+  @for $i from 0 through $length {
+    .selectedTab--#{$i} + & {
+      left: calc((#{$i} * -100%) + #{$container-edge-padding} + (#{$i} * 1px));
+    }
+  }
+
+  &__wrap {
+    width: calc(100vw - (#{$container-edge-padding} * 2));
+    overflow: hidden;
+  }
+}
+
 @mixin table--alternating-row-colors {
   tr:nth-child(odd) {
     th, td {

--- a/sass/directives/_tabs.scss
+++ b/sass/directives/_tabs.scss
@@ -1,4 +1,4 @@
-@mixin tabs {
+@mixin tabs($tabs) {
   &__tab-list {
     @include display(flex);
     width: 100%;
@@ -8,7 +8,7 @@
   &__tab {
     @include flex-grow(1);
     @include flex-shrink(0);
-    @include flex-basis(auto);
+    @include flex-basis(calc(1 / #{$tabs}));
     border-right: $base-border;
     padding: $base-spacing-small;
     list-style-type: none;

--- a/sass/directives/_tabs.scss
+++ b/sass/directives/_tabs.scss
@@ -8,7 +8,7 @@
   &__tab {
     @include flex-grow(1);
     @include flex-shrink(0);
-    @include flex-basis(calc(1 / #{$tabs}));
+    @include flex-basis(calc((1 / #{$tabs}) * 100%));
     border-right: $base-border;
     padding: $base-spacing-small;
     list-style-type: none;

--- a/sass/directives/_tabs.scss
+++ b/sass/directives/_tabs.scss
@@ -1,0 +1,29 @@
+@mixin tabs {
+  &__tab-list {
+    @include display(flex);
+    width: 100%;
+    border: $base-border;
+  }
+
+  &__tab {
+    @include flex-grow(1);
+    @include flex-shrink(0);
+    @include flex-basis(auto);
+    border-right: $base-border;
+    padding: $base-spacing-small;
+    list-style-type: none;
+    text-align: center;
+    text-transform: uppercase;
+    font-size: $small-font-size;
+    font-weight: $font-weight-bold;
+    color: $dark-text-color;
+
+    &:last-child {
+      border: 0;
+    }
+
+    &--selected {
+      color: white;
+    }
+  }
+}

--- a/sass/directives/_tabs.scss
+++ b/sass/directives/_tabs.scss
@@ -17,6 +17,7 @@
     font-size: $small-font-size;
     font-weight: $font-weight-bold;
     color: $dark-text-color;
+    cursor: pointer;
 
     &:last-child {
       border: 0;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -64,7 +64,7 @@ $type-margin: 20px;
 $type-margin--small: 12px;
 $type-indent: 2em;
 
-$container-edge-padding: 20px; //Use this if using an unconventional body container and still need the default left /right padding some of our containers have (20px)
+$container-edge-padding: 20px; //Use this if using an unconventional body container and still need the default left /right padding our .containers have (20px)
 
 // UI components
 $medium-icon-font-size: 25px;


### PR DESCRIPTION
**Purpose:**
> As a user looking to compare plans, I want to see a format the allows me to see the differences in features - at a glance, so I can pick the plan that is most appropriate for my business.

* Adds tabs and mobile table mixins

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1343

**Changes:**
* Changes to setup, Architectural changes, Migrations, Library changes, Side effects
  *

**Screenshots**
* Before
n/a
* After
![image](https://user-images.githubusercontent.com/2359538/27066691-8a900b6c-4fcb-11e7-9d57-d884d9307088.png)


**QA Links:**
http://web.employer-7.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-7.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

* Steps to take
  * Toggle between Monthly/Annual and verify prices change
  * Click tabs and verify data matches the selected tab
  * Verify under Lite there are no blank cells that show

* Responsive considerations
  * n/a


**Relevant PRs/Dependencies:**
#100 
https://github.com/cbdr/employer/pull/876

**Additional Information**
Note - page moves side to side on Safari. This appears to be from the overview section so it should be resolved when the mobile overview is done