### PR TITLE
EM-1306 and EM-1309: Header Large with Background Image and with Side Image

### DIFF
--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -19,8 +19,8 @@
     right: 0;
     width: 100%;
     height: 100%;
-    padding-top: $base-margin;
-    padding-bottom: $base-margin;
+    padding-top: $header-padding;
+    padding-bottom: $header-padding;
 
     @media only screen and (max-width: $small-screen-max) {
       position: relative;
@@ -161,6 +161,8 @@
 
 @mixin header--large--left {
   &__text {
+    max-width: $header-width-normal;
+
     p {
       @media only screen and (max-width: $small-screen-max) {
         display: none;

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -50,11 +50,11 @@
 @mixin header-hero--home($background-image-large, $background-image-medium: nil) {
   @include heading--hero;
   position: relative;
-  min-height: $header-height-large;
+  min-height: $header-height-home;
   overflow: hidden;
   background-color: $base-background-color;
   background-image: url(asset_path(#{$background-image-large}));
-  background-size: auto $header-height-large;
+  background-size: auto $header-height-home;
   background-position: right bottom;
   background-repeat: repeat no-repeat;
 
@@ -112,9 +112,9 @@
 @mixin header--large--background-image($background-image-large, $background-image-medium: nil) {
   @include header-hero;
   @include heading--hero;
-  min-height: $header-height-product;
+  min-height: $header-height-large;
   background-image: url(asset_path(#{$background-image-large}));
-  background-size: auto $header-height-product;
+  background-size: auto $header-height-large;
   background-position: right bottom;
   background-repeat: repeat no-repeat;
 
@@ -137,11 +137,11 @@
   }
 }
 
-@mixin header--large--side-image { // TODO refactor common styles into header--large
+@mixin header--large--side-image {
   @include header-hero;
   @include heading--hero;
   @include cbGradient;
-  min-height: $header-height-product; // TODO rename to header-height-large
+  min-height: $header-height-large;
 
   @media only screen and (max-width: $small-screen-max) {
     min-height: unset;

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -13,7 +13,7 @@
     @include flex-direction(column);
     @include justify-content(center);
     @include align-items(flex-start);
-    position: absolute;
+    position: absolute; // TODO this is all specific to background image + gradients
     top: 0;
     left: 0;
     right: 0;
@@ -138,31 +138,87 @@
 }
 
 @mixin header--large--side-image {
-  @include header-hero;
   @include heading--hero;
   @include cbGradient;
+  position: relative;
+  overflow: hidden;
   min-height: $header-height-large;
 
   @media only screen and (max-width: $small-screen-max) {
     min-height: unset;
   }
 
-  .header--large__image-wrap {
+  &__content-wrap {
+    @include display(flex);
+    @include justify-content(space-between);
     position: absolute;
-    bottom: 0;
+    top: 0;
+    left: 0;
     right: 0;
+    width: 100%;
+    height: 100%;
+
+    @media only screen and (max-width: $small-screen-max) {
+      position: relative;
+    }
+  }
+
+  &__text {
+    @include flex-grow(1);
+    @include flex-shrink(1);
+    @include flex-basis(auto);
+    @include display(flex);
+    @include flex-direction(column);
+    @include justify-content(center);
+    @include align-items(flex-start);
+    margin-right: $base-spacing-medium;
+    padding-top: $header-padding;
+    padding-bottom: $header-padding;
+
+    @media only screen and (max-width: $small-screen-max) {
+      position: relative;
+      padding-top: $header-top-bottom-padding;
+      padding-bottom: $header-top-bottom-padding;
+    }
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: $header-headline-bottom-margin;
+      line-height: normal;
+      color: $hero-text-color-light;
+
+      @media only screen and (max-width: $small-screen-max) {
+        margin-bottom: 0;
+      }
+    }
+
+    p {
+      margin-bottom: 0;
+      color: $hero-text-color-light;
+    }
+  }
+
+  .header--large__image-wrap {
+    @include flex-grow(1);
+    @include flex-shrink(0);
+    @include flex-basis(auto);
+    @include display(flex);
+    @include justify-content(flex-end);
+    @include align-items(flex-end);
+
+    @media only screen and (max-width: $small-screen-max) {
+      display: none;
+    }
   }
 
   .header--large__image {
     display: block;
-    max-width: 550px;
+    max-width: 34.375rem;
   }
 }
 
 @mixin header--large--left {
   &__text {
-    max-width: $header-width-normal;
-
     p {
       @media only screen and (max-width: $small-screen-max) {
         display: none;

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -146,13 +146,20 @@
   @media only screen and (max-width: $small-screen-max) {
     min-height: unset;
   }
+
+  .header--large__image-wrap {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+
+  .header--large__image {
+    display: block;
+    max-width: 550px;
+  }
 }
 
 @mixin header--large--left {
-  @media only screen and (max-width: $small-screen-max) {
-    background-image: none;
-  }
-
   &__text {
     p {
       @media only screen and (max-width: $small-screen-max) {

--- a/sass/directives/_headers.scss
+++ b/sass/directives/_headers.scss
@@ -109,7 +109,7 @@
   }
 }
 
-@mixin header--large($background-image-large, $background-image-medium: nil) {
+@mixin header--large--background-image($background-image-large, $background-image-medium: nil) {
   @include header-hero;
   @include heading--hero;
   min-height: $header-height-product;
@@ -135,7 +135,17 @@
     left: 0;
     @include cbGradientTransparent;
   }
+}
 
+@mixin header--large--side-image { // TODO refactor common styles into header--large
+  @include header-hero;
+  @include heading--hero;
+  @include cbGradient;
+  min-height: $header-height-product; // TODO rename to header-height-large
+
+  @media only screen and (max-width: $small-screen-max) {
+    min-height: unset;
+  }
 }
 
 @mixin header--large--left {

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -30,6 +30,7 @@ $base-spacing-xlarge: 70px;
 
 $section-padding: 70px;
 $section-padding--mobile: 50px;
+$header-padding: 70px;
 
 $container-edge-padding: 20px; // Use this if using an unconventional body container and still need the default left /right padding our .containers have (20px)
 
@@ -72,8 +73,7 @@ $header-height-home: 445px;
 $header-height-large: 455px;
 $header-top-bottom-padding: 32px;
 $header-headline-bottom-margin: 15px;
-
-
+$header-width-normal: 650px;
 
 // Tables
 $table-margin: $base-margin;

--- a/sass/variables/_sizing.scss
+++ b/sass/variables/_sizing.scss
@@ -68,8 +68,8 @@ $visual-guide-image-medium: 275px;
 $visual-guide-image-small: 170px;
 
 // Header
-$header-height-large: 445px;
-$header-height-product: 455px;
+$header-height-home: 445px;
+$header-height-large: 455px;
 $header-top-bottom-padding: 32px;
 $header-headline-bottom-margin: 15px;
 


### PR DESCRIPTION
**Purpose:**
> EM-1309: As a designer or a front end developer, I'd like the pages that use the "header_large" header partial to henceforth use the "header_large_solutions" partial (renaming the partial) so that going forward we have:
> EM-1306: As a designer or a front end developer, I'd like the product page headers to henceforth be known as "header_large" so that going forward we have

- a defined set of headers
- the same language for this header type
- generic, reusable components when we want to use this header type again


* I feel like this is an intermediate step between consolidating existing headers and making header large side and header large background the same thing. Right now these are two separate things per the stories, and they have significant differences in how the gradient backgrounds are added, but I think eventually they might be the same thing
   * But the side-image header was more different than I expected from the background image header, so maybe they won't be consolidated
* Includes EM-1306 which was already done and just had partial/mixin/class name changes
* EM-1309 mentions changes to the https://hiring.careerbuilder.com/recruiting-solutions/job-posting-and-candidate-profile-trends page, but that page was listed in the wrong place, no changes to it in this PR (it would be updated in https://github.com/cbdr/employer/pull/898)

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1306
https://cb-content-enablement.atlassian.net/browse/EM-1309

**Changes:**
* Changes to setup, Architectural changes, Migrations, Side effects
  *
  
* Library changes
  * style base updates

**Screenshots**
* Before
![image](https://user-images.githubusercontent.com/2359538/27675929-8acc0290-5c71-11e7-9737-961bd264cc58.png)

* After
![image](https://user-images.githubusercontent.com/2359538/27675918-8395b08e-5c71-11e7-9561-471d9f1a47cb.png)


**QA Links:**
http://d774a5d6.ngrok.io

**How to Verify These Changes**
* Specific pages to visit
  * product#default - http://d774a5d6.ngrok.io/recruiting-solutions/federated-resume-search
  * product#deluxe - http://d774a5d6.ngrok.io/recruiting-solutions/ofccp-compliance-mandatory-job-listing-reporting
  * product#jobs - http://d774a5d6.ngrok.io/recruiting-solutions/job-postings
  * product#search-rdb - http://d774a5d6.ngrok.io/recruiting-solutions/resume-database

* Steps to take
  * compare to dev
      * headers are larger and image now aligns to the outer edge of the .container class, otherwise the headers should appear the same
      * verify that Jobs header is unchanged compared to dev

* Responsive considerations
  * text should not overlap image
  * image disappears on mobile


**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/902

**Additional Information**
