### PR TITLE
EM-1593: Small Biz Overview Section Refactor (ESB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -117,8 +117,8 @@ $visual-guide-breakpoint-small: 750px;
     }
   }
 
-  // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
-  div.visual-guide__step {
+
+  .visual-guide__step {
     display: none;
     background-color: white;
     border: $visual-guide-step-border;
@@ -130,9 +130,8 @@ $visual-guide-breakpoint-small: 750px;
     width: $visual-guide-step-size;
     color: $text-color-dark;
 
-    div:after {
+    &:after {
       content: counter(overview-count);
-      margin-left: -2px; //Override IPE adding in &nbsp into this container
     }
 
     @media only screen and (min-width: $visual-guide-breakpoint-small) {

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -95,13 +95,6 @@ $visual-guide-breakpoint-small: 750px;
 
   .visual-guide__content {
     display: block;
-
-    @media only screen and (min-width: $visual-guide-breakpoint-small)
-    {
-      &.guide__content--left {
-        @include justify-content(flex-end);
-      }
-    }
   }
 
   .visual-guide__item-description {
@@ -147,6 +140,7 @@ $visual-guide-breakpoint-small: 750px;
       @include display(flex);
       @include justify-content(center);
       left: 0;
+      @include order(2);
       position: absolute;
       right: 0;
       top: 0;
@@ -159,13 +153,28 @@ $visual-guide-breakpoint-small: 750px;
     .visual-guide__content, .visual-guide__image {
       @include display(flex);
       width: 50%;
+    }
 
-      &:first-of-type {
+    &:nth-child(odd) {
+      .visual-guide__content {
+        @include justify-content(flex-end);
         margin-right: $base-spacing-xlarge;
+        @include order(1);
       }
-
-      &:last-of-type {
+      .visual-guide__image {
         margin-left: $base-spacing-xlarge;
+        @include order(3);
+      }
+    }
+
+    &:nth-child(even) {
+      .visual-guide__content {
+        margin-left: $base-spacing-xlarge;
+        @include order(3);
+      }
+      .visual-guide__image {
+        margin-right: $base-spacing-xlarge;
+        @include order(1);
       }
     }
   }

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -125,7 +125,7 @@ $visual-guide-breakpoint-small: 750px;
   }
 
   // The step must be within a <span>, not a <div>, and must contain another <span> for the actual counter
-  span.visual-guide__step {
+  div.visual-guide__step {
     display: none;
     background-color: white;
     border: $visual-guide-step-border;
@@ -137,7 +137,7 @@ $visual-guide-breakpoint-small: 750px;
     width: $visual-guide-step-size;
     color: $text-color-dark;
 
-    span:after {
+    div:after {
       content: counter(overview-count);
     }
 

--- a/sass/directives/_visual-guides.scss
+++ b/sass/directives/_visual-guides.scss
@@ -132,6 +132,7 @@ $visual-guide-breakpoint-small: 750px;
 
     div:after {
       content: counter(overview-count);
+      margin-left: -2px; //Override IPE adding in &nbsp into this container
     }
 
     @media only screen and (min-width: $visual-guide-breakpoint-small) {


### PR DESCRIPTION
**Purpose:**

> The Overview section of the Small Business subscription page was designed in a way that POs could remove one of the steps through IPE, but this is not working.
> 
> I can remove some (label and paragraph) but not others (headline). Also, when I remove the label copy and then add it back, it's no longer the correct color. It should be the dark anchor blue, but switches to demon gray. (See screen shot.) In talking to David, he thinks he will need to adjust how snippets are displayed so everything is in one box per step.

This ESB PR updates the Visual Guide mixin to use flexbox's ordering system. This allows a PO to reorganize the `<li>` elements whichever way they want without needing to edit the guts of these blocks. This will order those blocks based on even / odd rules.

I was able to successfully wrap the entire section in a snippet and edit its source in Cortex. But there are some quirks. See **Side effects** here https://github.com/cbdr/employer/pull/909

This also resolves the issue with the IPE adding additional markup when copy is edited, resulting in different colored text as seen on https://hiring.careerbuilder.com/recruiting-solutions/small-business-subscription-plans-and-pricing (the header of the first section).

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1593

**Changes:**
* Changes to setup
  * N/A

* Architectural changes
See `Architectural changes` in https://github.com/cbdr/employer/pull/909

* Migrations
  * N/A
  
* Library changes
  * N/A

* Side effects
  * See `Side effects` in https://github.com/cbdr/employer/pull/909
  * Most importantly, do not edit this page in mobile view!

**Screenshots**
* Before
N/A - This section (including its carousel) should look exactly as it currently does on https://hiring.careerbuilder.com/recruiting-solutions/small-business-subscription-plans-and-pricing (minus Stephanie's edits, like the grey header in the first step)
* After
N/A

**QA Links:**
http://web.cortex.development.c66.me/legacy#/webpages (small business subscription plans and pricing EM-2)
http://web.employer-2.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

**How to Verify These Changes**
* Specific pages to visit
  * http://web.cortex.development.c66.me/legacy#/webpages (`small business subscription plans and pricing EM-2`)
  *  http://web.employer-2.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

* Steps to take
  * Go ahead and compare the actual page to https://hiring.careerbuilder.com/recruiting-solutions/small-business-subscription-plans-and-pricing . Make sure the images resize correctly and that the carousel appears under 750px. Font styling should be the same. You should also not notice the grey header seen in hiringdot on the dev server. 
  * Edit the page through Cortex, in Desktop view - `small business subscription plans and pricing EM-2`. You should notice that the entire Overview section is editable now.
    * Try editing some copy through the IPE. Font color should not change.
    * More specifically, try editing the headers and the label used for the content step indicator.
    * View the source through IPE and try editing copy through that. Again, font color should not change.
    * View the source, and add / remove an entire `<li>` block. The step indicators should update. The rows should show even / odd ordering without needing to reorder the two blocks `visual-guide__content` (the main copy / content block) and `visual-guide__image` (the large image).
    * View the source, try reorganizing the `<li>` blocks. Again, the step indicators should update, and you should still see the even / odd ordering without needing to reorder `visual-guide__content` (the main copy / content block) and `visual-guide__image` (the large image).
    

* Responsive considerations
  * The carousel should still appear and display your updated changes.
  * As mentioned before, you **cannot** edit this page in mobile. Doing so will cause it to break. All the edits for mobile can be done in Desktop view anyway using `Source`.


**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/909

**Additional Information**
