### PR TITLE
Fix: Explicitly Set Button Font-Family to Lato

### DIFF
--- a/sass/directives/02_base_components/_button.scss
+++ b/sass/directives/02_base_components/_button.scss
@@ -35,6 +35,7 @@ $massive-button-horizontal-padding: $base-input-font-size * 2;
   border-radius: $button-border-radius;
   color: $base-button-text-color;
   display: inline-block;
+  font-family: $lato;
   font-size: $base-button-font-size;
   font-weight: $font-weight-bold;
   line-height: $base-button-line-height;


### PR DESCRIPTION
Fixes prod push issues where buttons were using system font instead of Lato:
- https://trello.com/c/7s5Jjgfa/63-jobs-rdb-subs-faq-questions-need-to-be-lato-not-arial
- https://trello.com/c/89WRnDnM/64-jobs-rdb-cta-button-on-buy-box-cta-needs-to-be-lato-not-arial
- https://trello.com/c/Sty1KHAO/69-homepage-labels-on-featured-products-section-need-to-be-lato-not-arial
 - https://trello.com/c/jaIIrK7d/68-newsletter-subscribe-box-font-is-wrong-for-cta-button

Adds `font-family` to the button mixin