### PR TITLE
Fix: Make All CTA Fonts Regular Weight

### DIFF
--- a/sass/selectors/_cta.scss
+++ b/sass/selectors/_cta.scss
@@ -18,7 +18,8 @@
   text-align: center;
   padding: $base-margin--small;
   // smaller font-size to fit "feedback"
-  font-size: 0.6875rem;
+  font-size: $font-size-smallest;
+  font-weight: $font-weight-regular;
   color: $grey-demon;
   border: $base-border;
   border-right: none;


### PR DESCRIPTION
Fixes prod push issue: https://trello.com/c/jhdULg4p/65-offers-tab-fonts-are-not-the-same-weight-across-the-three-buttons

 - `a` tags are bold by default. Two CTAs used `a` one uses a `div` (it needs to be a `button`)
 - now anything with `.cta__action-link` is `font-weight: $font-weight-regular;`
 - also replaced font size with one of our new variables (of equal value)