### PR TITLE
EM-1164: Gradient Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.15",
+  "version": "2.2.15-alpha.1",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.15-alpha.1",
+  "version": "2.2.16",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/02_base_components/_gradients.scss
+++ b/sass/directives/02_base_components/_gradients.scss
@@ -84,18 +84,12 @@ $gradient-angle: 135deg;
 
 @mixin gradient($dark, $medium, $light) {
   background: $dark; // Old browsers
-  background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // FF3.6-15
-  background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, $light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, $light 100%);
 }
 
 @mixin gradientTransparent($dark, $medium, $light, $transparency: 0.9) {
   background: $dark; // Old browsers
-  background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // FF3.6-15
-  background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
+  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%);
 }
 
 @mixin imageGradientBlend($img-url, $dark, $medium, $light, $mode: multiply) {

--- a/sass/directives/02_base_components/_gradients.scss
+++ b/sass/directives/02_base_components/_gradients.scss
@@ -106,15 +106,6 @@ $gradient_var_list: (
   background-attachment: fixed;
 }
 
-@mixin imageGradient($img-url, $dark, $medium, $light) {
-  background-color: $light;
-  background-image:
-    linear-gradient(to right, rgba($dark, 0.8), rgba($medium, 0.75), rgba($light, 0.2)),
-    url($img-url);
-  background-attachment: fixed;
-}
-
-
 // ## Gradient Implementation ##
 
 @mixin cbGradient {

--- a/sass/directives/02_base_components/_gradients.scss
+++ b/sass/directives/02_base_components/_gradients.scss
@@ -99,6 +99,12 @@ $gradient-angle: 135deg;
     url($img-url);
   background-blend-mode: $mode;
   background-attachment: fixed;
+
+  html[data-useragent*='Windows NT']:not([data-useragent*='Edge']) &,
+  html[data-useragent*='iPhone'] & {
+    background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, $light 100%);
+    background-blend-mode: unset;
+  }
 }
 
 // ## Gradient Implementation ##

--- a/sass/directives/02_base_components/_gradients.scss
+++ b/sass/directives/02_base_components/_gradients.scss
@@ -78,6 +78,7 @@ $gradient_var_list: (
   $lostWorld,
 );
 
+$gradient-angle: 135deg;
 
 // ## Gradient Mixins ##
 
@@ -85,7 +86,7 @@ $gradient_var_list: (
   background: $dark; // Old browsers
   background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // FF3.6-15
   background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, $light 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient(135deg, $dark 0%, $medium 35%, $light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, $light 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
 }
 
@@ -93,14 +94,14 @@ $gradient_var_list: (
   background: $dark; // Old browsers
   background: -moz-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // FF3.6-15
   background: -webkit-linear-gradient(-45deg, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // Chrome10-25,Safari5.1-6
-  background: linear-gradient(135deg, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
+  background: linear-gradient($gradient-angle, $dark 0%, $medium 35%, transparentize($light, $transparency) 100%); // W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$dark}', endColorstr='#{$light}',GradientType=1 ); // IE6-9 fallback on horizontal gradient
 }
 
 @mixin imageGradientBlend($img-url, $dark, $medium, $light, $mode: multiply) {
   background-color: $light;
   background-image:
-    linear-gradient(to right, rgba($dark, 0.8), rgba($medium, 0.75), rgba($light, 0.2)),
+    linear-gradient($gradient-angle, rgba($dark, 0.8), rgba($medium, 0.75), rgba($light, 0.2)),
     url($img-url);
   background-blend-mode: $mode;
   background-attachment: fixed;


### PR DESCRIPTION
**Purpose:**
> As a visitor, when I a section of Hiring Dot with a gradient, it doesn't look like it does on other browsers like how I see it on Safari.

* Uses our previously implemented user agent sniffing classes on `html` tag and directly targets iPhone and Windows browsers that are not Edge (i.e. IE). I'll ask POs if they'd like to include Edge b/c those gradients don't look great
*  Removed the non-blend version of imagegradient mixin because the blend version can be used for this (with `$mode: unset` argument)
* Removed browser prefixed versions of gradients to remove clutter for devs. On old browsers that we no longer support (IE 11-) it's not broken, it's just different (solid) so everybody wins 

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1164

**Changes:**
* Changes to setup,Architectural changes,Migrations,Side effects
  * n/a
  
* Library changes
  * bump style base

**Screenshots**
* Before - Home
![before](https://user-images.githubusercontent.com/2359538/28606707-f3b84bc4-719d-11e7-813f-c460f41c49f9.png)

Before - Small Biz
![before small biz](https://user-images.githubusercontent.com/2359538/28606843-ad71222a-719e-11e7-864c-5620cf2b8903.PNG)

Before - DY Tests
![before dy test png](https://user-images.githubusercontent.com/2359538/28606842-ad6fa274-719e-11e7-835d-7777b67de894.PNG)

* After - Home
![after](https://user-images.githubusercontent.com/2359538/28606706-f3b838d2-719d-11e7-9e32-361ad734fa8b.png)

After - Small Biz
![after small biz png](https://user-images.githubusercontent.com/2359538/28606841-ad6d529e-719e-11e7-88ab-131311b922be.PNG)

After - DY Tests
![after dy test](https://user-images.githubusercontent.com/2359538/28606840-ad6d4100-719e-11e7-9078-82863fe909af.PNG)


**QA Links:**
http://web.employer-6.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-6.development.c66.me/
  * http://web.employer-6.development.c66.me/dy-test
  * http://web.employer-6.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing

* Steps to take
  * Compare gradient+images (pictured above) on dev.hiring.careerbuilder.com for the pages listed above with the QA links. On QA links you should only see solid gradients in the places where dev has gradients with background patterns


* Responsive considerations
  * n/a


**Relevant PRs/Dependencies:**
https://github.com/cbdr/employer/pull/946

**Additional Information**
