### PR TITLE
EM-1449: Center Mobile Compare Chart Column Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/02_base_components/_tabs.scss
+++ b/sass/directives/02_base_components/_tabs.scss
@@ -6,9 +6,12 @@
   }
 
   &__tab {
+    @include display(flex);
     @include flex-grow(1);
     @include flex-shrink(0);
     @include flex-basis(calc((1 / #{$tabs}) * 100%));
+    @include justify-content(center);
+    @include align-items(center);
     @include font-style--small-bold-uppercase;
     border-right: $base-border;
     padding: $base-spacing-small;


### PR DESCRIPTION
**Purpose:**
This simply adds in Arelia's fix to center the column headers as mentioned here - https://github.com/cbdr/employer/pull/956#issuecomment-321401857

**JIRA:**
https://cb-content-enablement.atlassian.net/browse/EM-1449

**Notes:**
@arelia This ticket will be immediately merged. Just wanted to create the request for documentation.