### PR TITLE
EM-1145: Post Brand Simplification Clean Up (small-strip Refactor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.25",
+  "version": "2.2.26",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/02_base_components/accents/_accents.scss
+++ b/sass/directives/02_base_components/accents/_accents.scss
@@ -2,12 +2,12 @@
 //   box-shadow: 0 (2px * $z) (2px * $z) rgba(0, 0, 0, 0.2);
 // }
 
-@mixin small-strip {
+@mixin small-strip($strip-color: $anchor-blue) {
   content: '';
   height: $small-strip-height;
   border-top-right-radius: $minor-border-radius;
   border-top-left-radius: $minor-border-radius;
-  background-color: $anchor-blue;
+  background-color: $strip-color;
   position: absolute;
   top: 0;
   right: 0;
@@ -20,19 +20,6 @@
   margin: auto;
   margin-top: $type-margin;
   margin-bottom: $type-margin;
-}
-
-// The small strip changes for brand simplification
-@mixin bs__small-strip { // TODO we shouldn't need this anymore; if anything, add a background color parameter to @mixin small-strip
-  content: '';
-  height: $small-strip-height;
-  border-top-right-radius: $minor-border-radius;
-  border-top-left-radius: $minor-border-radius;
-  background-color: $lime-dark;
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
 }
 
 @mixin column-flag {

--- a/sass/directives/03_components/_cards.scss
+++ b/sass/directives/03_components/_cards.scss
@@ -1,4 +1,4 @@
-@mixin card--tile($scale: true, $include_strip: true) {
+@mixin card--tile($scale: true, $include_strip: true, $strip-color: $lime-dark) {
   @include component-box;
   @include display(flex);
   @include flex-direction(column);
@@ -14,7 +14,7 @@
     padding-top: calc(#{$base-spacing-medium} + #{$small-strip-height});
 
     &:before {
-      @include bs__small-strip;
+      @include small-strip($strip-color);
     }
   }
 


### PR DESCRIPTION
* Remove `@mixin bs-small-strip`
  * Nothing in Employer used this, so no change to Employer
* Refactor `@mixin small-strip` to use a color parameter
  * Added current color as default, so no change to anywhere this is used