### PR TITLE
Refactor (buttons): remove .button class styles from button element

### DIFF
--- a/sass/selectors/_buttons.scss
+++ b/sass/selectors/_buttons.scss
@@ -1,8 +1,4 @@
-.button,
-button,
-input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+.button {
   @include button;
 }
 


### PR DESCRIPTION
**Purpose:**
Devs can start with a blank button when creating something that is semantically a button but that should be styled differently

**Feature Branch:**
http://web.employer-6.development.c66.me/