### PR TITLE
Refactor: Remove Scoped Styling to P Tags For FAQ Panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.2.31",
+  "version": "2.2.32",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/03_components/accordion/_accordion.scss
+++ b/sass/directives/03_components/accordion/_accordion.scss
@@ -6,11 +6,8 @@
   overflow: hidden;
   opacity: 0;
   border-bottom: $accordion-bottom-border solid $grey-lightest;
-
-  p {
-    color: $text-color-grey;
-    padding-bottom: $base-padding;
-  }
+  color: $text-color-grey;
+  padding-bottom: $base-padding;
 }
 
 @mixin accordion__active_panel {


### PR DESCRIPTION
The accordion__panel targeted P tags only for the `padding-bottom: 24px;` but since the FAQ panels will now have multiple elements it's best to add that padding to the div itself. 

Additionally P tags already had a `margin-bottom: 20px;`: 
![developer tools - http web employer-3 development c66 me recruiting-solutions talent-network dummy 2017-10-04 12-26-52](https://user-images.githubusercontent.com/10361180/31190002-6b9b6a34-a8ff-11e7-8bd1-6f198cc66d5f.png)

Here is the difference: 
**Before:**
![dummy careerbuilder for employers 2017-10-04 12-28-37](https://user-images.githubusercontent.com/10361180/31190096-bc98c878-a8ff-11e7-8a71-a2c3783795a0.png)
**after:**
![dummy careerbuilder for employers 2017-10-04 12-29-25](https://user-images.githubusercontent.com/10361180/31190110-c67c263c-a8ff-11e7-997a-9b975552d2ad.png)
