### PR TITLE
CE-204: Gallery Widget (ESB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/02_base_components/modals/_modals.scss
+++ b/sass/directives/02_base_components/modals/_modals.scss
@@ -44,3 +44,46 @@
   right: -$close-x-overflow-size / 2;
   top: -$close-x-overflow-size / 2;
 }
+
+@mixin sample-product--modal {
+  padding: $base-spacing-smallest;
+  position: relative;
+  overflow: visible !important;
+
+  &--image {
+    height: 100%;
+    overflow-y: scroll;
+
+    img {
+      display: block;
+      width: 100%;
+    }
+  }
+
+  &--link {
+    background-color: $grey-darkest;
+    opacity: .9;
+    text-align: center;
+    position: absolute;
+    left: $base-spacing-smallest;
+    right: $base-spacing-smallest;
+    bottom: $base-spacing-smallest;
+    padding: $base-spacing-smallest;
+
+    a,
+    a:hover,
+    a:visited,
+    a:focus {
+      color: white;
+      @include font-style--med-regular;
+    }
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    height: 70vw;
+  }
+
+  .mfp-close {
+    @include close-x-overflow;
+  }
+}

--- a/sass/directives/03_components/cards/_cards.scss
+++ b/sass/directives/03_components/cards/_cards.scss
@@ -115,3 +115,142 @@
     @include flex-wrap(nowrap);
   }
 }
+
+// Galleries with filter
+@mixin card--tile__gallery-item {
+  @include transform(scale(1));
+  @include transition(transform 0.4s ease-in);
+
+  flex: 1;
+  margin: $base-spacing-medium / 2;
+  text-align: center;
+  font-weight: $font-weight-regular;
+
+  a:hover,
+  a:focus,
+  a:active {
+    text-decoration: none;
+  }
+
+  @media only screen and (min-width: $medium-screen-min) {
+    flex: 1 0 46%;
+  }
+
+  @media only screen and (min-width: $large-screen-min) {
+    flex: 1 0 25%;
+  }
+
+  @media only screen and (min-width: $small-screen-max) { // TODO turning off the fanciness on mobile but should there still be some sort of state for usability?
+    &:hover {
+      @include transform(scale(1.06));
+      @include transition(transform 550ms ease-out);
+    }
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+@mixin card--tile__gallery-image {
+  @include component-box;
+  border-radius: 0;
+  padding: 0;
+
+  img {
+    width: 100%;
+    display: block;
+  }
+}
+
+@mixin card--tile__gallery-subtext {
+
+  margin-top: $base-spacing-medium;
+
+  &--header {
+    @include font-style--small-bold-uppercase;
+    margin-bottom: $base-spacing-small;
+  }
+
+  &--text {
+    color: $text-color-grey;
+    font-style: italic;
+  }
+}
+
+@mixin card-deck--controls {
+  @include font-style--med-bold-uppercase;
+  text-align: center;
+  margin-bottom: $base-spacing-medium;
+
+  a {
+    margin-right: $base-spacing-medium;
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+
+    &.active {
+      padding-bottom: $base-spacing-smallest;
+      border-bottom: 2px solid $base-link-color;
+    }
+  }
+}
+
+@mixin card--deck__popup {
+  padding: $base-spacing-smallest;
+  position: relative;
+  overflow: visible !important;
+
+  &--image {
+    height: 100%;
+    overflow-y: scroll;
+
+    img {
+      display: block;
+      width: 100%;
+    }
+  }
+
+  &--link {
+    background-color: $grey-darkest;
+    opacity: .9;
+    text-align: center;
+    position: absolute;
+    left: $base-spacing-smallest;
+    right: $base-spacing-smallest;
+    bottom: $base-spacing-smallest;
+    padding: $base-spacing-smallest;
+
+    a,
+    a:hover,
+    a:visited,
+    a:focus {
+      color: white;
+      @include font-style--med-regular;
+    }
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    height: 70vw;
+  }
+
+  .mfp-close {
+    @include close-x-overflow;
+  }
+}

--- a/sass/directives/03_components/cards/_cards.scss
+++ b/sass/directives/03_components/cards/_cards.scss
@@ -116,8 +116,7 @@
   }
 }
 
-// Galleries with filter
-@mixin card--tile__gallery-item {
+@mixin card--tile--basic {
   @include transform(scale(1));
   @include transition(transform 0.4s ease-in);
 
@@ -161,7 +160,7 @@
   }
 }
 
-@mixin card--tile__gallery-image {
+@mixin card--tile__image($include_box-shadow: true) {
   @include component-box;
   border-radius: 0;
   padding: 0;
@@ -172,7 +171,7 @@
   }
 }
 
-@mixin card--tile__gallery-subtext {
+@mixin card--tile__caption {
 
   margin-top: $base-spacing-medium;
 
@@ -187,7 +186,7 @@
   }
 }
 
-@mixin card-deck--controls {
+@mixin card--deck__filters {
   @include font-style--med-bold-uppercase;
   text-align: center;
   margin-bottom: $base-spacing-medium;
@@ -209,48 +208,5 @@
       padding-bottom: $base-spacing-smallest;
       border-bottom: 2px solid $base-link-color;
     }
-  }
-}
-
-@mixin card--deck__popup {
-  padding: $base-spacing-smallest;
-  position: relative;
-  overflow: visible !important;
-
-  &--image {
-    height: 100%;
-    overflow-y: scroll;
-
-    img {
-      display: block;
-      width: 100%;
-    }
-  }
-
-  &--link {
-    background-color: $grey-darkest;
-    opacity: .9;
-    text-align: center;
-    position: absolute;
-    left: $base-spacing-smallest;
-    right: $base-spacing-smallest;
-    bottom: $base-spacing-smallest;
-    padding: $base-spacing-smallest;
-
-    a,
-    a:hover,
-    a:visited,
-    a:focus {
-      color: white;
-      @include font-style--med-regular;
-    }
-  }
-
-  @media only screen and (max-width: $small-screen-max) {
-    height: 70vw;
-  }
-
-  .mfp-close {
-    @include close-x-overflow;
   }
 }

--- a/sass/directives/03_components/cards/_cards.scss
+++ b/sass/directives/03_components/cards/_cards.scss
@@ -1,3 +1,47 @@
+@mixin card--tile--basic {
+  @include transform(scale(1));
+  @include transition(transform 0.4s ease-in);
+
+  flex: 1;
+  margin: $base-spacing-medium / 2;
+  text-align: center;
+  font-weight: $font-weight-regular;
+
+  a:hover,
+  a:focus,
+  a:active {
+    text-decoration: none;
+  }
+
+  @media only screen and (min-width: $medium-screen-min) {
+    flex: 1 0 46%;
+  }
+
+  @media only screen and (min-width: $large-screen-min) {
+    flex: 1 0 25%;
+  }
+
+  @media only screen and (min-width: $small-screen-max) { // TODO turning off the fanciness on mobile but should there still be some sort of state for usability?
+    &:hover {
+      @include transform(scale(1.06));
+      @include transition(transform 550ms ease-out);
+    }
+  }
+
+  @media only screen and (max-width: $small-screen-max) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
 @mixin card--tile($scale: true, $include_strip: true, $strip-color: $lime-dark) {
   @include component-box;
   @include display(flex);
@@ -113,50 +157,6 @@
   @media only screen and (max-width: $small-screen-max) {
     @include flex-direction(column);
     @include flex-wrap(nowrap);
-  }
-}
-
-@mixin card--tile--basic {
-  @include transform(scale(1));
-  @include transition(transform 0.4s ease-in);
-
-  flex: 1;
-  margin: $base-spacing-medium / 2;
-  text-align: center;
-  font-weight: $font-weight-regular;
-
-  a:hover,
-  a:focus,
-  a:active {
-    text-decoration: none;
-  }
-
-  @media only screen and (min-width: $medium-screen-min) {
-    flex: 1 0 46%;
-  }
-
-  @media only screen and (min-width: $large-screen-min) {
-    flex: 1 0 25%;
-  }
-
-  @media only screen and (min-width: $small-screen-max) { // TODO turning off the fanciness on mobile but should there still be some sort of state for usability?
-    &:hover {
-      @include transform(scale(1.06));
-      @include transition(transform 550ms ease-out);
-    }
-  }
-
-  @media only screen and (max-width: $small-screen-max) {
-    width: 100%;
-    margin-left: 0;
-    margin-right: 0;
-
-    &:first-child {
-      margin-top: 0;
-    }
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 }
 


### PR DESCRIPTION
**Purpose**
> As a visitor, I want to see the examples of the different types of Talent Networks available and I want to be able to sort through, click on an example to see more.

Because I figured that reusing Arelia's really nice card mixins for the new Gallery Widget would be great, this PR introduces some new modifications to `_cards.scss` to account for the Gallery Widget cards. Now these can simply be included anywhere in Employer to add some new flavor for additional galleries, whether they use `Mixitgallery` or not.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-204

**Changes**
* Improvements and fixes
  * Adds a few new mixins targeting the Gallery Widget created for Employer / Cortex

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before

* After
![screen shot 2017-10-12 at 5 14 54 pm](https://user-images.githubusercontent.com/5348098/31521904-e9c71fe4-af70-11e7-8ca6-7d7d533345e1.png)

**Feature Server**
http://web.employer-6.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-6.development.c66.me/recruiting-solutions/talent-network

* Steps to take
  * Make sure the page looks ok, and compare it to the mockup (https://careerbuilder.invisionapp.com/share/CYCNKU9PA#/236997525_HiringDot_TalentNetwork_Desktop_1600)
  * Make sure the hover animations work

* Responsive considerations
  * Resize this page to mobile or test it on your phone. The cards should reduce to two columns (tablet) then one column for mobile. The modal should also resize appropriately.

**Relevant PRs/Dependencies** 
  * https://github.com/cbdr/employer/pull/1013

**Additional Information**
N/A