### PR TITLE
CE-203: Talent Network Stories Section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/03_components/montage/_montage.scss
+++ b/sass/directives/03_components/montage/_montage.scss
@@ -15,6 +15,8 @@ $_montage_winglet_width: 15px;
 $_montage_winglet_offset: 15%;
 $_montage_mobile_bp: 750px;
 $_montage_tablet_bp: 1145px;
+$_montage_external-cta_bottom-position: 18px;
+$_montage_external-cta_bottom-position_tablet: 5px;
 
 @mixin montage-subheader {
   color: $_montage-highlight;
@@ -85,6 +87,7 @@ $_montage_tablet_bp: 1145px;
 
   // Elements
   .montage__cell {
+    position: relative;
     min-height: 200px;
 
     @media only screen and (max-width: $_montage_mobile_bp) {
@@ -343,6 +346,22 @@ $_montage_tablet_bp: 1145px;
         align-self: center;
         text-align: center;
       }
+    }
+  }
+
+  .montage__external-link {
+    display: block;
+    margin-top: $base-spacing-smallest;
+    text-align: center;
+
+    @media only screen and (min-width: $_montage_mobile_bp) {
+      margin-top: auto;
+      position: absolute;
+      bottom: $_montage_external-cta_bottom-position;
+    }
+
+    .fa-angle-double-right {
+      font-size: $font-size-med;
     }
   }
 


### PR DESCRIPTION
**Purpose**
This just adds in styling for the `Read More >>` link that was missing in the stories section of both the App Tracking and Talent Network pages.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-203

**Changes**
* Improvements and fixes
  * See above

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * The `Read More >>` link will need to be updated on Prod for both the App Tracking and Talent Network pages.
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A

* After
![screen shot 2017-10-16 at 4 21 05 pm](https://user-images.githubusercontent.com/5348098/31635887-0ac00826-b28e-11e7-90f5-184041d67d7c.png)

**Feature Server**
http://dev.admin.cbcortex.com/
http://web.employer-1.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * http://dev.admin.cbcortex.com/legacy#/webpages (`employer-1 talent network dummy`)
  * http://web.employer-1.development.c66.me/recruiting-solutions/talent-network/dummy
  * http://web.employer-1.development.c66.me/recruiting-solutions/applicant-tracking (to compare)

* Steps to take
  * Make sure the stories section looks the same as the one found on the App Tracking page. It should respond the same when you resize your browser
  * Go to Cortex and edit some parts in the section. Copy was not updated on this server as it will be updated on prod
  * You should see the Read More link. You will need to edit the source of the `Products Used` section to successfully edit this link

* Responsive considerations
  * It should respond the same as it does on the App Tracking page. The carousel should be present on mobile as well.

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1015

**Additional Information**
N/A