### PR TITLE
CE-341: Page Refactors (ESB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/03_components/headers/_headers.scss
+++ b/sass/directives/03_components/headers/_headers.scss
@@ -281,12 +281,23 @@
 
 // Text alignment
 
-@mixin header--large--left($hide-description-mobile: true) {
+@mixin header--large--left($hide-description-mobile: true, $header-mobile-font-size: null, $paragraph-mobile-font-size: null) {
   &__text {
     @if $hide-description-mobile {
       p {
         @media only screen and (max-width: $small-screen-max) {
           display: none;
+        }
+      }
+    }
+
+    @if $header-mobile-font-size != null {
+      @media only screen and (max-width: $small-screen-max) {
+        h1 {
+          font-size: $header-mobile-font-size;
+        }
+        p {
+          font-size: $paragraph-mobile-font-size;
         }
       }
     }

--- a/sass/directives/03_components/headers/_headers.scss
+++ b/sass/directives/03_components/headers/_headers.scss
@@ -281,11 +281,13 @@
 
 // Text alignment
 
-@mixin header--large--left {
+@mixin header--large--left($hide-description-mobile: true) {
   &__text {
-    p {
-      @media only screen and (max-width: $small-screen-max) {
-        display: none;
+    @if $hide-description-mobile {
+      p {
+        @media only screen and (max-width: $small-screen-max) {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
**Purpose**
> As a visitor, I just want to make sure the page has all the jzugsh it needs to make me feel compelled to scroll, click things and ultimately buy a million dollars worth of products.

This modifies the `header--large--left` mixin so that it accept arguments to show/hide the CTA header text and to adjust the fonts for mobile.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-341

**Changes**
* Improvements and fixes
  * The header mixin used (`header--large--left`) for the Applicant Tracking, Talent Discovery, and Talent Network was revised to use a boolean to show/hide the CTA and paragraph text on mobile and to use two new arguments to adjust the size of the fonts for mobile

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
![screen shot 2017-10-25 at 11 50 53 am](https://user-images.githubusercontent.com/5348098/32011608-dcdb52c8-b97a-11e7-8a8d-ee87ab0f5abf.png)

* After
![screen shot 2017-10-25 at 11 51 15 am](https://user-images.githubusercontent.com/5348098/32011613-e188e10a-b97a-11e7-9789-2e90bbeae4bd.png)

**Feature Server**
http://web.employer-2.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-2.development.c66.me/recruiting-solutions/applicant-tracking
  * http://web.employer-2.development.c66.me/recruiting-solutions/talent-discovery
  * http://web.employer-2.development.c66.me/recruiting-solutions/talent-network
  * http://web.employer-2.development.c66.me/recruiting-solutions/small-business-subscription-plans-and-pricing
  * http://web.employer-2.development.c66.me/employment-screening/
  * http://web.employer-2.development.c66.me/company/why-careerbuilder

* Steps to take
  * Go to each of the pages and make sure they look ok compared to their hiringDot versions. There should be no visual changes besides the adjustments for the headers on the TN, AT, and TD pages.
  * Go to the Talent Network, App Tracking, and Talent Discovery pages and resize each of the headers down to mobile. The header should begin scaling and the background image should disappear. For each of these pages, the CTA header should still be present.
  * Visit the other pages and resize their headers, there should be no changes

* Responsive considerations
  * Look at the TN, AT, and TD pages on your phone and check the headers

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1025

**Additional Information**
N/A