### PR TITLE
CE-394: Increase Margin of ESB Subhead

### DIFF
--- a/sass/directives/00_variables/typography/_typography.scss
+++ b/sass/directives/00_variables/typography/_typography.scss
@@ -48,6 +48,7 @@ $base-line-height: 1.5;
 $header-line-height: 1.25;
 
 // Type Spacing
+$type-margin-xlarge: 40px;
 $type-margin-large: 28px; // hero headers
 $type-margin-medium: 25px;
 $type-margin: 20px;

--- a/sass/directives/02_base_components/headings/_headings.scss
+++ b/sass/directives/02_base_components/headings/_headings.scss
@@ -44,7 +44,7 @@
 }
 
 @mixin heading--section--w-subhead {
-  margin-bottom: $type-margin;
+  margin-bottom: $type-margin-xlarge;
 
   &__heading {
     @include font-style--med-bold-uppercase;


### PR DESCRIPTION
**Purpose**
> As a visitor, I'd like to see a bit more breathing room below a product page's feature sub head and the listed features. Right now it feels jammed together.

The mixin `heading--section--w-subhead` had its bottom margin upped from 20px to 40px. This was to fix some problems (mainly with the Features section found on pages like Talent Network) where the margin was too small.

This mainly affects the style `.employer-section__header--subhead` which is being used on a number of pages and their associated sections.

Other styles that were affected in Employer and ESB are `.small-biz__benefits__banner-text` and `.heading--section--w-subhead`, which is found in the Selectors folder in ESB. These styles however not relevant to this change as they're not in use or the bottom margin is being overridden.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-394

**Changes**
* Improvements and fixes
  * Ups bottom margin of the mixin `heading--section--w-subhead` from 20px to 40px

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * There might be an after effect where some pages now have larger bottom margins for sub-headers, but an audit was conducted on the site to create a sheet with all the affected pages and sections found on the site. The Jira for this ticket has a .doc file on hand detailing this.

**Screenshots**
* Before
![screen shot 2017-10-31 at 1 14 16 pm](https://user-images.githubusercontent.com/5348098/32241177-789574c0-be3d-11e7-9ac2-9f37da7b652c.png)

* After
![screen shot 2017-10-31 at 1 14 07 pm](https://user-images.githubusercontent.com/5348098/32241183-7bec9356-be3d-11e7-8ee0-30d06a6071d8.png) 

**Feature Server**
http://web.employer-3.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * Homepage
     * Product categories section
     * Featured resources section
     * Featured products section
  * http://web.employer-3.development.c66.me/recruiting-solutions/applicant-tracking
     * Featured resources section
     * Additional products section
     * Features section
     * Customer stories section
  * http://web.employer-3.development.c66.me/employment-screening
     * CB difference section
     * Featured resources section
     * Employment screening services section
     * Video section ("Technology  You'll  Love")
  * http://web.employer-3.development.c66.me/talent-discovery
     * Additional products section
     * Featured resources section
     * Features section
  * http://web.employer-3.development.c66.me/talent-network
     * Customer stories
     * Featured resources section
     * Additional products section
     * Features section
     * Our work section (gallery)
  * http://web.employer-3.development.c66.me/talent-network
     * CB difference section
     * Our solutions section
     * Our data section
     * Integrations and partnerships section
     * Success stories (video) section

* Steps to take
  * Go to each of the pages and their sections and verify that the headers still look ok (check on desktop and mobile)
  * Besides the increase in the bottom margin, nothing else should change

* Responsive considerations
  * There should be no visible changes for the bottom margin on mobile for the above pages

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1033

**Additional Information**
See the .doc file in the Jira (CE-394-Header-Audit.docx)