### PR TITLE
CE-399: Product Card Mixin Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -46,6 +46,7 @@
 
 // 04 Utilities - helper classes and overrides
 @import "directives/04_utilities/visibility";
+@import "directives/04_utilities/reset";
 
 
 // Selectors - classes and element selectors which implement directives

--- a/sass/directives/02_base_components/headings/_headings.scss
+++ b/sass/directives/02_base_components/headings/_headings.scss
@@ -63,6 +63,8 @@
   @include font-style--small-bold-uppercase;
   margin-bottom: $type-margin--small;
   color: $header-text-color;
+
+  @include reset-paragraph;
 }
 
 @mixin heading--small {

--- a/sass/directives/04_utilities/_reset.scss
+++ b/sass/directives/04_utilities/_reset.scss
@@ -5,6 +5,8 @@
     padding: 0 !important;
     font-size: inherit !important;
     font-weight: inherit !important;
+    font-family: inherit !important;
     display: inline !important;
+    text-decoration: inherit !important;
   }
 }

--- a/sass/directives/04_utilities/_reset.scss
+++ b/sass/directives/04_utilities/_reset.scss
@@ -1,0 +1,10 @@
+@mixin reset-paragraph {
+  p {
+    color: inherit !important;
+    margin:0 !important;
+    padding: 0 !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    display: inline !important;
+  }
+}


### PR DESCRIPTION
**Purpose**
> The titles on the product tile cards have a tendency to change from anchor blue to gray. We need to add a revised style for the product cards to prevent the `<h3>` from changing colors because, in one of the mixins used for these cards, it wasn't set up right to account for CKE dropping in `<p>` tags.

This PR adds in a new reset mixin to reset paragraphs to a default style. This mixin can be included elsewhere when needed.

In this case, the mixin `heading--item`, which controls the headers of the product cards, now includes this reset mixin to override paragraph styles for dropped in `<p>` tags by CKEditor.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-399

**Changes**
* Improvements and fixes
  * The titles in the product cards should no longer turn grey
  * No need to use `.ck-no-style` for the `<h3>` or `<snippet>` tags
  * A PO can now just edit raw text in the product title in the product cards, even if CKEditor drops a `<p>` tag in.
  * New reset mixin introduce that can be used in other places
  * `heading--item` mixin has been updated to include the reset mixin for paragraphs

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A
* After
N/A

**Feature Server**
http://dev.admin.cbcortex.com/legacy#/webpages
http://web.employer-6.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * Cortex - `employer-6 applicant tracking`
  * http://web.employer-6.development.c66.me/recruiting-solutions/applicant-tracking

* Steps to take
  * Go to the `Additional Products` section and edit the titles of the cards (because of the click functionality of these cards, you might have to right click the cards to bring up the editor)
  * The titles should no longer turn grey, even with raw text and the absence of the class `.ck-no-style`
  * Go to the actual web page and inspect the titles of the product cards, you should notice the <p> tag CKEditor dropped in. But it should still remain blue and you should notice the styles for the paragraph being overridden.

* Responsive considerations
  * N/A

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1034

**Additional Information**
N/A