### PR TITLE
bugfix: Mobile SubNav Z-Index Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/03_components/flyout/_flyout.scss
+++ b/sass/directives/03_components/flyout/_flyout.scss
@@ -95,6 +95,7 @@
     &:hover {
       ul {
         display: block;
+        z-index: 1;
       }
 
       .mobile-subnav__top-link {

--- a/sass/directives/03_components/flyout/_flyout.scss
+++ b/sass/directives/03_components/flyout/_flyout.scss
@@ -95,7 +95,7 @@
     &:hover {
       ul {
         display: block;
-        z-index: 1;
+        z-index: z($z-context, sticky-nav, $sticky-nav, sticky-nav);
       }
 
       .mobile-subnav__top-link {


### PR DESCRIPTION
On mobile the subnav flyout had a few issues: 

**Before:**
![post jobs careerbuilder for employers 2017-11-09 10-52-32](https://user-images.githubusercontent.com/10361180/32618445-5e347ff2-c53d-11e7-8ba3-02ee522b98e3.png)
http://web.employer-5.development.c66.me/recruiting-solutions/post-jobs

**After:**
![post jobs careerbuilder for employers 2017-11-09 10-52-48](https://user-images.githubusercontent.com/10361180/32618470-6d7c78f2-c53d-11e7-94e8-87f64b55c633.png)

http://web.employer-6.development.c66.me/recruiting-solutions/post-jobs
