### PR TITLE
CE-772: Kill Buy Box (UI Only, ESB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "employer-style-base",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "author": "EmployerSiteContentProducts@cb.com",
   "license": "Apache-2.0",
   "description": "A stack-agnostic Sass library providing basic components and typography intended for the Employer experience",

--- a/sass/directives/02_base_components/forms/_forms.scss
+++ b/sass/directives/02_base_components/forms/_forms.scss
@@ -240,4 +240,8 @@ $select-arrow-width: 3em;
       border-bottom-right-radius: $base-border-radius;
     }
   }
+
+  &__incrementer-input {
+    min-width: 0;
+  }
 }

--- a/sass/directives/02_base_components/forms/_forms.scss
+++ b/sass/directives/02_base_components/forms/_forms.scss
@@ -203,3 +203,9 @@ $select-arrow-width: 3em;
     color: white;
   }
 }
+
+@mixin error-message {
+  @include font-style--smallest-regular;
+  margin-top: $base-spacing-smallest;
+  color: $red;
+}

--- a/sass/directives/02_base_components/forms/_forms.scss
+++ b/sass/directives/02_base_components/forms/_forms.scss
@@ -209,3 +209,35 @@ $select-arrow-width: 3em;
   margin-top: $base-spacing-smallest;
   color: $red;
 }
+
+// Styling for an incrementers with +/- buttons and an input
+@mixin incrementer_group {
+  display: flex;
+  align-items: stretch;
+  box-shadow: $base-box-shadow;
+  border-radius: $base-border-radius;
+
+  &__incrementer {
+    flex: 0 0 $buy-header-qty-button-width;
+    color: $grey-dark;
+    cursor: pointer;
+    background-color: $grey-lighter;
+    border: none;
+
+    &:hover {
+      color: white;
+      background-color: $sky-blue;
+      border-color: $sky-blue;
+    }
+
+    &:first-child {
+      border-top-left-radius: $base-border-radius;
+      border-bottom-left-radius: $base-border-radius;
+    }
+
+    &:last-child {
+      border-top-right-radius: $base-border-radius;
+      border-bottom-right-radius: $base-border-radius;
+    }
+  }
+}

--- a/sass/selectors/_buttons.scss
+++ b/sass/selectors/_buttons.scss
@@ -55,6 +55,10 @@ button {
   @include massive-button;
 }
 
+.button.button--negative {
+  @include negative-button;
+}
+
 .disabled {
   @include disabled;
 


### PR DESCRIPTION
**Purpose**
> Given I am on this route, https://hiring.careerbuilder.com/recruiting-solutions/post-job-online-now,
I see the new interactive header UI and not the old Buy Box

Per the Jira, this adds in styling and base states for the new Buy Header that may replace the Buy Box.

This PR includes the mixins for the incrementer group and a new styled error message.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-772

**Changes**
* Improvements and fixes
  * New mixins for an incrementer group and error message

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
<img width="1314" alt="screen shot 2018-03-29 at 4 58 39 pm" src="https://user-images.githubusercontent.com/5348098/38115708-9a21ab40-3372-11e8-8a38-81a4e61b2cbe.png">

* After
<img width="1269" alt="screen shot 2018-03-29 at 4 59 23 pm" src="https://user-images.githubusercontent.com/5348098/38115718-9fcb1fd6-3372-11e8-91f7-bfead3bc053c.png">

**Feature Server**
http://web.employer-4.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-4.development.c66.me/recruiting-solutions/post-job-online-now

* Steps to take
  * Pull down the repo, and comb over the file and design of the page, to verify that each state is styled correctly
  * In your editor, pull out sections to show header states individually
  * Verify the incrementer looks ok in FF and Chrome
  * Resize the browser to test the shards
  * Resize the browser to test the left image
  * Verify IPE has been included or has been marked

* Responsive considerations
  * All states should collapse to a tablet / mobile view, and the shards should adjust. Verify this styling against the comps.

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1114

**Additional Information**
N/A