### PR TITLE
CE-1428: MS Edge / IE Nav Bug

### DIFF
--- a/sass/directives/03_components/flyout/_flyout.scss
+++ b/sass/directives/03_components/flyout/_flyout.scss
@@ -38,6 +38,7 @@
 
   ul li {
     list-style-type: none;
+    list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7); // IE / Edge Hack since the browser 'forgets' to apply the style to hidden <li> elements
   }
 
   ul li a {


### PR DESCRIPTION
**Purpose**
> As a user, I should not see list styling for items in the main navigation while using MS Edge or IE 11+.

This is an interesting bug that appears only in IE 11 and the latest of MS Edge and affects our usage of `list-style-type: none`. This only impacts `<li>` elements that are hidden from view using `display: none` as we're doing with the navigation. The browser 'forgets' that the `list-style-type` property exists and is not applied. Thus, when a user displays the menu, list styling still appears. 

See the following links for more information:
https://twitter.com/fremycompany/status/950856311083683840
https://github.com/webhintio/webhint.io/issues/210
(*solution*) https://stackoverflow.com/questions/20356311/internet-explorer-11-ignores-list-stylenone-on-the-first-load

The solution is to use the following line:
`url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);`

It essentially spoofs an image that doesn't work. Shouldn't cause a slow down on the page either due to network activity.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-1428

**Changes**
* Improvements and fixes
  * List styling no longer appears in MS Edge, IE.

* Changes to developer setup/environment
  * `package.json` to be updated in Employer to address this patch
  * ESB version update

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * N/A
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
![ie-list-styles](https://user-images.githubusercontent.com/5348098/43796983-79fafac0-9a4b-11e8-9b0c-e208f57cd833.png)

* After
![screen shot 2018-08-07 at 2 07 39 pm](https://user-images.githubusercontent.com/5348098/43796939-571e9dcc-9a4b-11e8-8ff9-c3819aff2284.png)

**Feature Server**
http://web.employer-6.development.c66.me/

**How to Verify These Changes**
* Specific pages to visit
  * Any page

* Steps to take
  * View the navigation using MS Edge / IE 11. You should not see list styling anymore.

* Responsive considerations
  * View the mobile menus. The same should apply.

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1143

**Additional Information**
I need to clarify with Kristy about the tiny text seen in IE. This may be due to her screen or browser usage. 