### PR TITLE
CE-1498: New Gradients

### DIFF
--- a/sass/directives/00_variables/colors/_colors.scss
+++ b/sass/directives/00_variables/colors/_colors.scss
@@ -1,6 +1,7 @@
 // Color Definitions
 
 // CB Main Branding Colors
+$anchor-blue-dark: #1C202A;
 $anchor-blue: #182642;
 $anchor-blue-light: #747d8e;
 
@@ -53,6 +54,8 @@ $purple-medium: #673ab7;
 $purple-light: #b389ff;
 
 $red: #DD2C00;
+
+$transparent: rgba(255, 255, 255, 0);
 
 // CB Gradient
 $cb-gradient-dark: #0A3A68;

--- a/sass/directives/02_base_components/gradients/_gradients.scss
+++ b/sass/directives/02_base_components/gradients/_gradients.scss
@@ -60,6 +60,19 @@ $lostWorld: (
   light: $lime
 );
 
+// New CB Brand Gradient - To replace old gradient
+$deviant: (
+  dark: $anchor-blue-dark,
+  medium: $anchor-blue,
+  light: $azure-blue
+);
+
+$deviant-2: (
+  dark: $anchor-blue-dark,
+  medium: $anchor-blue,
+  light: $transparent
+);
+
 $gradient_name_list: (
   cb,
   cbAlternate,
@@ -71,6 +84,8 @@ $gradient_name_list: (
   purpleRain,
   moonlight,
   lostWorld,
+  deviant,
+  deviant-2
 );
 
 $gradient_var_list: (
@@ -84,6 +99,8 @@ $gradient_var_list: (
   $purpleRain,
   $moonlight,
   $lostWorld,
+  $deviant,
+  $deviant-2
 );
 
 $gradient-angle: 135deg;
@@ -205,4 +222,20 @@ $gradient-angle: 135deg;
 
 @mixin lostWorldGradientTransparent {
   @include gradientTransparent(map-get($lostWorld, dark), map-get($lostWorld, medium), map-get($lostWorld, light));
+}
+
+@mixin deviantGradient {
+  @include gradient(map-get($deviant, dark), map-get($deviant, medium), map-get($deviant, light));
+}
+
+@mixin deviantGradientTransparent {
+  @include gradientTransparent(map-get($deviant, dark), map-get($deviant, medium), map-get($deviant, light));
+}
+
+@mixin deviantGradient-2 {
+  @include gradient(map-get($deviant-2, dark), map-get($deviant-2, medium), map-get($deviant-2, light));
+}
+
+@mixin deviantGradient-2Transparent {
+  @include gradientTransparent(map-get($deviant-2, dark), map-get($deviant-2, medium), map-get($deviant-2, light));
 }

--- a/sass/selectors/_gradients.scss
+++ b/sass/selectors/_gradients.scss
@@ -78,18 +78,18 @@
   @include lostWorldGradientTransparent;
 }
 
-.deviant {
+.deviantGradient {
   @include deviantGradient;
 }
 
-.deviantTransparent {
+.deviantGradientTransparent {
   @include deviantGradientTransparent;
 }
 
-.deviant-2 {
+.deviantGradient-2 {
   @include deviantGradient-2;
 }
 
-.deviant-2Transparent {
+.deviantGradient-2Transparent {
   @include deviantGradient-2Transparent;
 }

--- a/sass/selectors/_gradients.scss
+++ b/sass/selectors/_gradients.scss
@@ -77,3 +77,19 @@
 .lostWorldGradientTransparent {
   @include lostWorldGradientTransparent;
 }
+
+.deviant {
+  @include deviantGradient;
+}
+
+.deviantTransparent {
+  @include deviantGradientTransparent;
+}
+
+.deviant-2 {
+  @include deviantGradient-2;
+}
+
+.deviant-2Transparent {
+  @include deviantGradient-2Transparent;
+}


### PR DESCRIPTION
**Purpose**
> As a PO / Director, I should be able to use / see new gradients across the site at my discretion.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-1498

**Changes**
* Improvements and fixes
  * Four new gradients created in the stylebase - `deviantGradient` and `deviantGradient-2` and their transparent versions

* Changes to developer setup/environment
  * New stylebase update and version. Plan to merge in CE-1482 (MS IE Bug) in the stylebase as well which will be a part of `2.3.0`
  * Need to run yarn install

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * Need to publish new ESB version
  * Need to update `package.json` with new ESB version
  
* Library changes
  * N/A

* Side effects
  * N/A

**Screenshots**
* Before
N/A

* After
![screen shot 2018-09-10 at 2 59 15 pm](https://user-images.githubusercontent.com/5348098/45321138-229fd280-b50a-11e8-8d75-eee6b7421b72.png)

**Feature Server**
http://web.employer-6.development.c66.me

**How to Verify These Changes**
* Specific pages to visit
  * http://web.employer-6.development.c66.me

* Steps to take
  * Verify the new gradients on the 4 slides in the homepage carousel and that they're correctly applied to their containers

* Responsive considerations
  * The image should still disappear on mobile, but the gradients should remain.

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1151

**Additional Information**
For now, only the new gradients will go out with tomorrow's push. The update that will allow a PO to change the background on mobile will go out on Thursday.