### PR TITLE
CE-2343: Style Base Fonts

### DIFF
--- a/sass/directives/00_variables/_top_bar.scss
+++ b/sass/directives/00_variables/_top_bar.scss
@@ -10,8 +10,8 @@ $top-bar--subnav-offset: 44px;
 $top-bar--height: $top-bar--logo-height + ($top-bar--padding * 2);
 $top-bar--height-combined: $top-bar--height * 2;
 
-$top-bar-font-size: $font-size-small;
-$top-bar-icon-size: $font-size-small; // 13px
+$top-bar-font-size: $font-size-base;
+$top-bar-icon-size: $font-size-base; // 13px
 $top-bar-angle-size: 1rem; // 16px
 $top-bar-link-color: $anchor-blue;
 $top-bar-account-icon-color: $sky-blue;

--- a/sass/directives/00_variables/_top_bar.scss
+++ b/sass/directives/00_variables/_top_bar.scss
@@ -1,10 +1,10 @@
 // Top Bar
 $top-bar--max-width: 1430px;
-$top-bar--padding: 10px;
+$top-bar--padding: 12px;
 $top-bar--height--mobile: 42px;
 $top-bar--logo-width: 209px;
 $top-bar--logo-height: 22px;
-$top-bar--subnav-offset: 44px;
+$top-bar--subnav-offset: 47px;
 
 // These affect positioning of the hero, subnav, buy box, search modal
 $top-bar--height: $top-bar--logo-height + ($top-bar--padding * 2);

--- a/sass/directives/00_variables/typography/_type_styles.scss
+++ b/sass/directives/00_variables/typography/_type_styles.scss
@@ -32,7 +32,7 @@
 }
 
 @mixin font-style--med-regular { // Style 7: body copy
-  font-size: $font-size-med;
+  font-size: $font-size-med-large;
   font-weight: $font-weight-regular;
 }
 

--- a/sass/directives/00_variables/typography/_type_styles.scss
+++ b/sass/directives/00_variables/typography/_type_styles.scss
@@ -5,7 +5,7 @@
 }
 
 @mixin font-style--xl-light {  // Style 2: section headers and subheaders
-  font-size: $font-size-xl;
+  font-size: $font-size-xl-base;
   font-weight: $font-weight-light;
 }
 

--- a/sass/directives/00_variables/typography/_typography.scss
+++ b/sass/directives/00_variables/typography/_typography.scss
@@ -8,6 +8,7 @@ $header-font-family: $lato;
 
 // Font Sizes - Standard
 $font-size-xxl: 2.75rem; // 44px
+$font-size-xl-base: 2rem;
 $font-size-xl: 1.875rem; // 30px
 $font-size-large: 1.375rem; // 22px
 $font-size-med: 0.9375rem; // 15px

--- a/sass/directives/00_variables/typography/_typography.scss
+++ b/sass/directives/00_variables/typography/_typography.scss
@@ -11,6 +11,7 @@ $font-size-xxl: 2.75rem; // 44px
 $font-size-xl-base: 2rem;
 $font-size-xl: 1.875rem; // 30px
 $font-size-large: 1.375rem; // 22px
+$font-size-med-large: 1.25rem;
 $font-size-med: 0.95rem; // 15px
 $font-size-small: 0.8125rem; // 13px
 $font-size-smallest: 0.6875rem; // 11px

--- a/sass/directives/00_variables/typography/_typography.scss
+++ b/sass/directives/00_variables/typography/_typography.scss
@@ -11,7 +11,7 @@ $font-size-xxl: 2.75rem; // 44px
 $font-size-xl-base: 2rem;
 $font-size-xl: 1.875rem; // 30px
 $font-size-large: 1.375rem; // 22px
-$font-size-med: 0.9375rem; // 15px
+$font-size-med: 0.95rem; // 15px
 $font-size-small: 0.8125rem; // 13px
 $font-size-smallest: 0.6875rem; // 11px
 $font-size-base: 1rem;

--- a/sass/directives/00_variables/typography/_typography.scss
+++ b/sass/directives/00_variables/typography/_typography.scss
@@ -13,6 +13,7 @@ $font-size-large: 1.375rem; // 22px
 $font-size-med: 0.9375rem; // 15px
 $font-size-small: 0.8125rem; // 13px
 $font-size-smallest: 0.6875rem; // 11px
+$font-size-base: 1rem;
 
 // Font Sizes - Non-Standard
   // NOTE: Use namespacing so usage is clear.

--- a/sass/directives/02_base_components/button/_button.scss
+++ b/sass/directives/02_base_components/button/_button.scss
@@ -1,6 +1,6 @@
 // Button Sizes
 $base-button-font-size: $font-size-med;
-$base-button-vertical-padding: $base-input-font-size * 0.375;
+$base-button-vertical-padding: $base-input-font-size * 0.8;
 $base-button-horizontal-padding: $base-input-font-size * 1.375;
 $base-button-border-size: 2px;
 $base-button-border-size--text: 3px;

--- a/sass/directives/02_base_components/forms/_forms.scss
+++ b/sass/directives/02_base_components/forms/_forms.scss
@@ -141,7 +141,7 @@ $active-radio-box-shadow: 0 0 0 8px $alert-primary-active inset, 0 0 0 16px whit
 $form-input-font-size: $base-font-size;
 
 $form-input-vertical-padding: $form-input-font-size * 0.6;
-$form-input-horizontal-padding: $form-input-font-size * 1.25;
+$form-input-horizontal-padding: $form-input-font-size * 2;
 $base-input-border-size: 1px;
 $base-input-line-height: $base-line-height;
 

--- a/sass/directives/02_base_components/headings/_headings.scss
+++ b/sass/directives/02_base_components/headings/_headings.scss
@@ -60,7 +60,7 @@
 }
 
 @mixin heading--item {
-  @include font-style--small-bold-uppercase;
+  @include font-style--med-bold-uppercase ;
   margin-bottom: $type-margin--small;
   color: $header-text-color;
 


### PR DESCRIPTION
**Purpose**
> The content on the hiring.careerbuilder.com site is too small to read and does not match the UX guidelines for the pages.

This PR updates styling of our base font sizes so that they are bigger on the Hiring site. This includes adjustments to padding and the base font size of the style base. Some new font sizing variables were added to this as well.

**JIRA**
https://careerbuilder.atlassian.net/browse/CE-2343

**Changes**
* Improvements and fixes
  * Font sizes of headers, paragraphs, and subheaders were increased for this project.

* Changes to developer setup/environment
  * N/A

* Architectural changes
  * Font sizing variables were increased
  * Padding adjusted for some containers like headers

* Migrations or Steps to Take on Production
  * Verify that the site looks ok after release
  
* Library changes
  * N/A

* Side effects
  * These changes impact the overall look of the site, please inspect.

**Screenshots**
* Before
![Screen Shot 2020-03-17 at 3 50 36 PM](https://user-images.githubusercontent.com/5348098/76900296-11562580-6867-11ea-8c70-b7da7f79b724.png)

* After
![Screen Shot 2020-03-17 at 3 50 25 PM](https://user-images.githubusercontent.com/5348098/76900305-161ad980-6867-11ea-9c24-3b452ca7b558.png)

**Feature Server**
http://stg.hiring.careerbuilder.com/

**How to Verify These Changes**
* Specific pages to visit
  * All pages

* Steps to take
  * Verify that fonts look ok on the Hiring site
  * Verify that mobile styling persists

* Responsive considerations
  * See above

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1215

**Additional Information**
N/A