### PR TITLE
RDP-37186: H1 Style Base Refactor

### DIFF
--- a/sass/directives/02_base_components/headings/_headings.scss
+++ b/sass/directives/02_base_components/headings/_headings.scss
@@ -1,6 +1,5 @@
 @mixin heading--hero {
   h1 {
-    @include font-style-xl-bold-responsive;
     margin-bottom: 0;
   }
 

--- a/sass/directives/02_base_components/headings/_headings.scss
+++ b/sass/directives/02_base_components/headings/_headings.scss
@@ -74,7 +74,6 @@
 
 @mixin heading--small {
   h1 {
-    @include font-style-xl-bold-responsive;
     margin-bottom: 0;
   }
 

--- a/sass/directives/03_components/headers/_headers.scss
+++ b/sass/directives/03_components/headers/_headers.scss
@@ -34,7 +34,6 @@ $header-hero-carousel-dot-top: -50px;
     h1 {
       margin-top: 0;
       margin-bottom: $header-headline-bottom-margin;
-      color: $hero-text-color-light;
 
       @media only screen and (max-width: $small-screen-max) {
         margin-bottom: 0;
@@ -368,8 +367,6 @@ $header-hero-carousel-dot-top: -50px;
     h1 {
       margin-top: 0;
       margin-bottom: $header-headline-bottom-margin;
-      line-height: normal;
-      color: $hero-text-color-light;
 
       @media only screen and (max-width: $small-screen-max) {
         margin-bottom: 0;

--- a/sass/directives/03_components/headers/_headers.scss
+++ b/sass/directives/03_components/headers/_headers.scss
@@ -34,7 +34,6 @@ $header-hero-carousel-dot-top: -50px;
     h1 {
       margin-top: 0;
       margin-bottom: $header-headline-bottom-margin;
-      line-height: normal;
       color: $hero-text-color-light;
 
       @media only screen and (max-width: $small-screen-max) {

--- a/sass/directives/03_components/headers/_headers.scss
+++ b/sass/directives/03_components/headers/_headers.scss
@@ -435,9 +435,6 @@ $header-hero-carousel-dot-top: -50px;
 
     @if $header-mobile-font-size != null {
       @media only screen and (max-width: $small-screen-max) {
-        h1 {
-          font-size: $header-mobile-font-size;
-        }
         p {
           font-size: $paragraph-mobile-font-size;
         }

--- a/sass/selectors/_typography.scss
+++ b/sass/selectors/_typography.scss
@@ -1,9 +1,9 @@
 // Defaults Type Styles - overridden by classes or mixins
 
-h1 {
+/*h1 {
   @include base-heading-copy;
   @include font-style-xl-bold-responsive;
-}
+}*/
 
 h2 {
   @include base-heading-copy;

--- a/sass/selectors/_typography.scss
+++ b/sass/selectors/_typography.scss
@@ -1,10 +1,4 @@
 // Defaults Type Styles - overridden by classes or mixins
-
-/*h1 {
-  @include base-heading-copy;
-  @include font-style-xl-bold-responsive;
-}*/
-
 h2 {
   @include base-heading-copy;
   @include font-style-xl-bold-responsive;


### PR DESCRIPTION
**Purpose**
This PR refactors the Employer repo and the Style Base so that our H1 fonts are more consistent and easily manageable on the Hiring site.

In Part 1 we only focus on the H1 font as a demonstration, in Part 2, we plan to work on H2, H3, and P all at once.

In a Possible Part 3, we will address section elements and headers.

**JIRA**
https://careerbuilder.atlassian.net/browse/RDP-37186

**Changes**
* Improvements and fixes
  * Developers can now simply use an H1 tag on any Hiring page without a worry of the Style Base or redundant fonts interfering 
  * H1 font style is globally controlled by variables for both mobile and desktop, thus a developer simply needs to update the variables to update the website (unless page specific styles are overriding the H1 class, like in some cases where the font is supposed to be white)
  * Less dependence on the legacy Style Base
  * New, refined common styles, easily located in the Employer repo
  * Style guide was updated for the H1 common set - [Hiring Style Guide](https://careerbuilder.atlassian.net/wiki/spaces/EC/pages/3437396024/Hiring+Style+Guide)

* Changes to developer setup/environment
  * package.json will be updated to the new Style Base version of this update
  * common.scss was updated with new styles and variables
  * various page specific stylesheets had redundant code removed

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * Will need to analyze Cortex data to ensure that interfering inline styles or classes are not replacing our new CSS rules
  * Will have to update package.json to the new version number of the Style Base after we publish it to NPM
  
* Library changes
  * Style base was updated to a new version and thus requires publishing though NPM

* Side effects
  * Style Base

**Screenshots**
* Before

![Screenshot 2023-11-06 at 12 31 07 PM](https://github.com/cbdr/employer/assets/5348098/2f21cea6-df0c-48df-bc29-c35359093d68)
![Screenshot 2023-11-06 at 12 30 20 PM](https://github.com/cbdr/employer/assets/5348098/92d61c2c-ce7f-431b-a13f-e872cacfe2a2)

* After

![Screenshot 2023-11-06 at 9 49 09 AM](https://github.com/cbdr/employer/assets/5348098/02fee8e3-dcf5-4fd1-8bfe-9d00dfce40bd)

**Feature Server**
https://stg.hiring.careerbuilder.com

**How to Verify These Changes**
* Specific pages to visit
  * Entire site

* Steps to take
  * Go through each page and analyze the H1 tags with this new implementation. Generally, you should only see alignment styles being applied to the H1 font. Otherwise, the base styles for the H1 font should only be seen
  * Attempt on local to create an H1 class in a template, you should strictly see the new styling and nothing more being applied
  * Cortex will have to be analyzed of old conflicting in-line styles and classes that are being stored in the CMS

* Responsive considerations
  * One style should take place in mobile

![Screenshot 2023-11-06 at 12 39 50 PM](https://github.com/cbdr/employer/assets/5348098/360fb210-50c8-4d65-8706-a5548e7a2ae8)

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1534

**Additional Information**
N/A