### PR TITLE
RDP-29507: H2/H3/P Tag Font Standards - Style Base

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -32,7 +32,6 @@
 @import "directives/03_components/card_group/card_group";
 @import "directives/03_components/cards/cards";
 @import "directives/03_components/carousels/carousels";
-@import "directives/03_components/features_list/features_list";
 @import "directives/03_components/flyout/flyout";
 @import "directives/03_components/headers/headers";
 @import "directives/03_components/layout_quad/layout_quad";

--- a/sass/directives/03_components/visual_guides/_visual_guides.scss
+++ b/sass/directives/03_components/visual_guides/_visual_guides.scss
@@ -102,17 +102,6 @@ $visual-guide-breakpoint-small: 750px;
   }
 
   .visual-guide__item-description {
-    h3 {
-      letter-spacing: $letter-spacing-small;
-      font-size: $font-size-base;
-      font-weight: $font-weight-bold;
-      margin-bottom: $base-spacing;
-
-      @media only screen and (min-width: $medium-screen-min) {
-        font-size: $font-size-med-small;
-      }
-    }
-
     p {
       color: $text-color-grey;
     }

--- a/sass/selectors/_typography.scss
+++ b/sass/selectors/_typography.scss
@@ -1,14 +1,4 @@
 // Defaults Type Styles - overridden by classes or mixins
-h2 {
-  @include base-heading-copy;
-  @include font-style-xl-bold-responsive;
-}
-
-h3 {
-  @include base-heading-copy;
-  @include font-style-med-small-bold;
-}
-
 h4 {
   @include base-heading-copy;
   @include font-style--med-bold-uppercase;
@@ -24,10 +14,6 @@ h5 {
 h6 {
   @include base-heading-copy;
   @include font-style--small-bold;
-}
-
-p {
-  margin-bottom: $type-margin;
 }
 
 // Other Default Typography


### PR DESCRIPTION
**Purpose**
This PR refactors the Employer repo and the Style Base so that our H2, H3, and P fonts are more consistent and easily manageable on the Hiring site.

**JIRA**
https://careerbuilder.atlassian.net/browse/RDP-39993

**Changes**
* Improvements and fixes
  * Developers can now simply use an H2, H3, or P tag on any Hiring page without a worry of the Style Base or redundant fonts interfering
  *Font style is globally controlled by variables for both mobile and desktop, thus a developer simply needs to update the variables to update the website (unless page specific styles are overriding the H2, H3, P class, like in some cases where the font is supposed to be white)
  * Less dependence on the legacy Style Base
  * New, refined common styles, easily located in the Employer repo
  * Style guide was updated for these fonts - https://careerbuilder.atlassian.net/wiki/spaces/EC/pages/3437396024/Hiring+Style+Guide

* Changes to developer setup/environment
  * package.json will be updated to the new Style Base version of this update
  * common.scss was updated with new styles and variables
  * various page specific stylesheets had redundant code removed

* Architectural changes
  * N/A

* Migrations or Steps to Take on Production
  * Will need to analyze Cortex data to ensure that interfering inline styles or classes are not replacing our new CSS rules
  * Will have to update package.json to the new version number of the Style Base after we publish it to NPM  

* Library changes
  * Style base was updated to a new version and thus requires publishing though NPM

* Side effects
  * Style Base

**Screenshots**
H2 Font Set Example:
![Screenshot 2024-01-16 at 2 50 59 PM](https://github.com/cbdr/employer/assets/5348098/1a49a023-6cbe-4851-a2fa-03506763401b)

H3 Font Set Example:
![Screenshot 2024-01-16 at 2 49 38 PM](https://github.com/cbdr/employer/assets/5348098/64fbca4e-90d8-42ca-8d95-7e4c8f35cd67)

P Font Set Example:
![Screenshot 2024-01-16 at 2 50 27 PM](https://github.com/cbdr/employer/assets/5348098/8ff87dbe-afed-4b58-b844-51ad33c8565c)

**Feature Server**
https://stg.careerbuilder.com

**How to Verify These Changes**
* Specific pages to visit
  * Entire site

* Steps to take
  * Go through each page and analyze the H2/H3/P tags with this new implementation. Generally, you should only see alignment styles being applied to these fonts. Otherwise, the base styles should only be seen.
  * Attempt on local to create an H2/H3/P class in a template, you should strictly see the new styling and nothing more being applied.
  * Cortex will have to be analyzed of old conflicting in-line styles and classes that are being stored in the CMS.

* Responsive considerations
  * Please review mobile as well for issues.

**Relevant PRs/Dependencies**
  * https://github.com/cbdr/employer/pull/1549

**Additional Information**
N/A